### PR TITLE
fix: install deps for npm package

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -1,7 +1,5 @@
 name: Publish Package to Github Package NPM Registry
 on:
-  pull_request:
-    branches: [main]
   release:
     types: [created]
 jobs:


### PR DESCRIPTION
Adding a missing required step for the `npm publish` action: installing brownie (the package publication was tested here with a temporary PR-push trigger).