### PR TITLE
fix: add missing package json fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "version": "1.0.0",
   "description": "Topos Smart Contracts",
+  "files": [
+    "brownie/build"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toposware/topos-smart-contracts.git"
+  },
   "main": "",
   "scripts": {
     "build": "brownie compile",


### PR DESCRIPTION
The `npm` package was created correctly but wasn't including the build artifacts. Were missing the `files` field that defines what is packaged (`brownie/build` in our case) and `repository` (listed as required on Github Package's documentation).