### PR TITLE
fix: rename cert height to cert position

### DIFF
--- a/brownie/contracts/executables/ToposExecutable.sol
+++ b/brownie/contracts/executables/ToposExecutable.sol
@@ -32,10 +32,10 @@ contract ToposExecutable is IToposExecutable {
         subnetId originSubnetId,
         address originAddress,
         bytes32 selector,
-        uint256 minimumCertHeight
+        uint256 minimumCertPosition
     ) external onlyAdmin {
-        _setAuthorizedOrigin(originSubnetId, originAddress, selector, minimumCertHeight);
-        emit OriginAuthorized(originSubnetId, originAddress, selector, minimumCertHeight);
+        _setAuthorizedOrigin(originSubnetId, originAddress, selector, minimumCertPosition);
+        emit OriginAuthorized(originSubnetId, originAddress, selector, minimumCertPosition);
     }
 
     function execute(
@@ -43,14 +43,14 @@ contract ToposExecutable is IToposExecutable {
         ContractCallData memory contractCallData,
         bytes calldata /*crossSubnetTxProof*/
     ) external override {
-        uint256 certHeight = toposCoreContract.verifyContractCallData(certId, contractCallData.destinationSubnetId);
+        uint256 certPosition = toposCoreContract.verifyContractCallData(certId, contractCallData.destinationSubnetId);
         if (_isContractCallExecuted(contractCallData) == true) revert ContractCallAlreadyExecuted();
-        uint256 minimumCertHeight = _isAuthorizedOrigin(
+        uint256 minimumCertPosition = _isAuthorizedOrigin(
             contractCallData.originSubnetId,
             contractCallData.originAddress,
             contractCallData.selector
         );
-        if (certHeight <= minimumCertHeight) revert UnauthorizedOrigin();
+        if (certPosition <= minimumCertPosition) revert UnauthorizedOrigin();
 
         // prevent re-entrancy
         _setContractCallExecuted(contractCallData);
@@ -67,17 +67,17 @@ contract ToposExecutable is IToposExecutable {
         ContractCallWithTokenData memory contractCallWithTokenData,
         bytes calldata /*crossSubnetTxProof*/
     ) external override {
-        uint256 certHeight = toposCoreContract.verifyContractCallData(
+        uint256 certPosition = toposCoreContract.verifyContractCallData(
             certId,
             contractCallWithTokenData.destinationSubnetId
         );
         if (_isContractCallAndMintExecuted(contractCallWithTokenData) == true) revert ContractCallAlreadyExecuted();
-        uint256 minimumCertHeight = _isAuthorizedOrigin(
+        uint256 minimumCertPosition = _isAuthorizedOrigin(
             contractCallWithTokenData.originSubnetId,
             contractCallWithTokenData.originAddress,
             contractCallWithTokenData.selector
         );
-        if (certHeight <= minimumCertHeight) revert UnauthorizedOrigin();
+        if (certPosition <= minimumCertPosition) revert UnauthorizedOrigin();
 
         // prevent re-entrancy
         _setContractCallExecutedWithMint(contractCallWithTokenData);
@@ -144,9 +144,9 @@ contract ToposExecutable is IToposExecutable {
         subnetId originSubnetId,
         address originAddress,
         bytes32 selector,
-        uint256 minimumCertHeight
+        uint256 minimumCertPosition
     ) internal {
-        _setUint256(_getAuthorizedOriginsKey(originSubnetId, originAddress, selector), minimumCertHeight);
+        _setUint256(_getAuthorizedOriginsKey(originSubnetId, originAddress, selector), minimumCertPosition);
     }
 
     function _isAdmin(address account) internal view returns (bool) {

--- a/brownie/contracts/topos-core/ToposCoreContract.sol
+++ b/brownie/contracts/topos-core/ToposCoreContract.sol
@@ -52,11 +52,11 @@ contract ToposCoreContract is IToposCoreContract, AdminMultisigBase {
     \*******************/
 
     function verifyCertificate(bytes memory certBytes) external onlyAdmin {
-        (bytes memory certId, uint256 certHeight) = abi.decode(certBytes, (bytes, uint256));
+        (bytes memory certId, uint256 certPosition) = abi.decode(certBytes, (bytes, uint256));
         Certificate memory storedCert = verifiedCerts[certId];
         if (storedCert.isVerified == true) revert CertAlreadyVerified();
         if (!_verfiyCertificate(certId)) revert InvalidCert();
-        Certificate memory newCert = Certificate({certId: certId, height: certHeight, isVerified: true});
+        Certificate memory newCert = Certificate({certId: certId, position: certPosition, isVerified: true});
         verifiedCerts[certId] = newCert;
         emit CertVerified(certId);
     }
@@ -233,7 +233,7 @@ contract ToposCoreContract is IToposCoreContract, AdminMultisigBase {
         Certificate memory storedCert = getVerfiedCert(certId);
         if (storedCert.isVerified == false) revert CertNotVerified();
         if (!_validateDestinationSubnetId(destinationSubnetId)) revert InvalidSubnetId();
-        return storedCert.height;
+        return storedCert.position;
     }
 
     /***********\

--- a/brownie/interfaces/IToposCoreContract.sol
+++ b/brownie/interfaces/IToposCoreContract.sol
@@ -26,7 +26,7 @@ interface IToposCoreContract {
 
     struct Certificate {
         bytes certId;
-        uint256 height;
+        uint256 position;
         bool isVerified;
     }
 

--- a/brownie/interfaces/IToposExecutable.sol
+++ b/brownie/interfaces/IToposExecutable.sol
@@ -11,7 +11,12 @@ interface IToposExecutable {
     error ContractCallAlreadyExecuted();
     error UnauthorizedOrigin();
 
-    event OriginAuthorized(subnetId originSubnetId, address originAddress, bytes32 selector, uint256 minimumCertHeight);
+    event OriginAuthorized(
+        subnetId originSubnetId,
+        address originAddress,
+        bytes32 selector,
+        uint256 minimumCertPosition
+    );
 
     struct ContractCallData {
         bytes txHash;
@@ -43,7 +48,7 @@ interface IToposExecutable {
         subnetId originSubnetId,
         address originAddress,
         bytes32 selector,
-        uint256 minimumCertHeight
+        uint256 minimumCertPosition
     ) external;
 
     function execute(

--- a/brownie/tests/integration/test_send_token.py
+++ b/brownie/tests/integration/test_send_token.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 # Constants
 approve_amount = 50
 daily_mint_limit = 100
-dummy_cert_height = 12
+dummy_cert_position = 12
 dummy_cert_id = brownie.convert.to_bytes("0xdeaf", "bytes")
 dummy_data = brownie.convert.to_bytes("0x00", "bytes")
 mint_amount = 100
@@ -164,7 +164,7 @@ def send_token():
 
 def validate_dummy_cert(topos_core_contract):
     cert_params = ["bytes", "uint256"]
-    cert_values = [dummy_cert_id, dummy_cert_height]
+    cert_values = [dummy_cert_id, dummy_cert_position]
     encoded_cert_params = eth_abi.encode(cert_params, cert_values)
     topos_core_contract.verifyCertificate(
         encoded_cert_params, {"from": accounts[0]}

--- a/brownie/tests/integration/test_xs_contract_call.py
+++ b/brownie/tests/integration/test_xs_contract_call.py
@@ -18,10 +18,10 @@ LOGGER = logging.getLogger(__name__)
 
 # constants
 arbitrary_call_value = "This is a test message"
-dummy_cert_height = 11
+dummy_cert_position = 11
 dummy_cert_id = brownie.convert.to_bytes("0xdeaf", "bytes")
 dummy_xs_proof = brownie.convert.to_bytes("0x0002", "bytes")
-min_cert_height_admin = 10
+min_cert_position_admin = 10
 subnet_A_id = brownie.convert.to_bytes("0x01", "bytes32")
 subnet_B_id = brownie.convert.to_bytes("0x02", "bytes32")
 selector_hash = keccak.new(
@@ -134,7 +134,7 @@ def switch_network(subnet_network):
 
 def validate_dummy_cert(topos_core_contract):
     cert_params = ["bytes", "uint256"]
-    cert_values = [dummy_cert_id, dummy_cert_height]
+    cert_values = [dummy_cert_id, dummy_cert_position]
     encoded_cert_params = eth_abi.encode(cert_params, cert_values)
     topos_core_contract.verifyCertificate(
         encoded_cert_params, {"from": accounts[0]}
@@ -173,7 +173,7 @@ def approve_and_execute_on_receiving_subnet(
         origin_subnet_id,
         origin_address,
         selector,
-        min_cert_height_admin,
+        min_cert_position_admin,
         {"from": accounts[0]},
     )
 

--- a/brownie/tests/unit/const.py
+++ b/brownie/tests/unit/const.py
@@ -3,14 +3,14 @@ import brownie
 # const
 APPROVE_AMOUNT = 10
 CERT_BYTES = "0xdeaf"
-CERT_HEIGHT = 5
+CERT_POSITION = 5
 CERT_ID = brownie.convert.to_bytes(CERT_BYTES, "bytes")
 DAILY_MINT_LIMIT = 100
 DESTINATION_SUBNET_ID = brownie.convert.to_bytes("0x02", "bytes32")
 DUMMY_DATA = brownie.convert.to_bytes("0x00", "bytes")
 ENDPOINT = brownie.convert.to_bytes("0xdead", "bytes")
 LOGO_URL = brownie.convert.to_bytes("0xdeed", "bytes")
-MINIMUM_CERT_HEIGHT = 4
+MINIMUM_CERT_POSITION = 4
 MINT_AMOUNT = 10
 MINT_CAP = 1000
 ORIGIN_SUBNET_ID = brownie.convert.to_bytes("0x01", "bytes32")

--- a/brownie/tests/unit/test_topos_core_contract.py
+++ b/brownie/tests/unit/test_topos_core_contract.py
@@ -676,7 +676,7 @@ def test_verify_contract_call_data_reverts_on_unidentified_subnet_id(
         )
 
 
-def test_verify_contract_call_returns_cert_height(
+def test_verify_contract_call_returns_cert_position(
     admin, topos_core_contract_A
 ):
     fixture_subnet_id = c.ORIGIN_SUBNET_ID
@@ -684,13 +684,13 @@ def test_verify_contract_call_returns_cert_height(
     tx = topos_core_contract_A.verifyContractCallData(
         c.CERT_ID, fixture_subnet_id, {"from": admin}
     )
-    assert tx == c.CERT_HEIGHT
+    assert tx == c.CERT_POSITION
 
 
 # internal functions #
 def verify_cert(admin, topos_core_contract_A):
     return topos_core_contract_A.verifyCertificate(
-        eth_abi.encode(["bytes", "uint256"], [c.CERT_ID, c.CERT_HEIGHT]),
+        eth_abi.encode(["bytes", "uint256"], [c.CERT_ID, c.CERT_POSITION]),
         {"from": admin},
     )
 

--- a/brownie/tests/unit/test_topos_executable.py
+++ b/brownie/tests/unit/test_topos_executable.py
@@ -21,7 +21,7 @@ def test_authorize_origin_emits_event(accounts, admin, topos_executable):
         brownie.convert.datatypes.HexString(c.ORIGIN_SUBNET_ID, "bytes32"),
         dummy_address,
         brownie.convert.datatypes.HexString(get_selector_hash(), "bytes32"),
-        c.MINIMUM_CERT_HEIGHT,
+        c.MINIMUM_CERT_POSITION,
     ]
 
 
@@ -31,7 +31,7 @@ def test_execute_reverts_on_unverified_cert_id(
     invalid_cert_id = brownie.convert.to_bytes("0xdead", "bytes")
     dummy_address = accounts.add()
     topos_core_contract_B.verifyCertificate(
-        get_encoded_cert_params(c.CERT_ID, c.CERT_HEIGHT), {"from": admin}
+        get_encoded_cert_params(c.CERT_ID, c.CERT_POSITION), {"from": admin}
     )
     data = get_call_contract_data(dummy_address, c.DESTINATION_SUBNET_ID)
     # should revert since the cert is unverified
@@ -47,7 +47,7 @@ def test_execute_reverts_on_false_destination_id(
     invalid_destination_subnet_id = brownie.convert.to_bytes("0x03", "bytes32")
     dummy_address = accounts.add()
     topos_core_contract_B.verifyCertificate(
-        get_encoded_cert_params(c.CERT_ID, c.CERT_HEIGHT), {"from": admin}
+        get_encoded_cert_params(c.CERT_ID, c.CERT_POSITION), {"from": admin}
     )
     data = get_call_contract_data(dummy_address, invalid_destination_subnet_id)
     # should revert since destination subnet id is incorrect
@@ -63,7 +63,7 @@ def test_execute_reverts_on_contract_call_already_executed(
     dummy_address = accounts.add()
     authorize_origin(dummy_address, admin, topos_executable)
     topos_core_contract_B.verifyCertificate(
-        get_encoded_cert_params(c.CERT_ID, c.CERT_HEIGHT), {"from": admin}
+        get_encoded_cert_params(c.CERT_ID, c.CERT_POSITION), {"from": admin}
     )
     data = get_call_contract_data(dummy_address, c.DESTINATION_SUBNET_ID)
     topos_executable.execute(c.CERT_ID, data, c.DUMMY_DATA, {"from": admin})
@@ -74,17 +74,17 @@ def test_execute_reverts_on_contract_call_already_executed(
         )
 
 
-def test_execute_reverts_on_cert_height_lower_than_min_height(
+def test_execute_reverts_on_cert_position_lower_than_min_position(
     accounts, admin, topos_core_contract_B, topos_executable
 ):
     dummy_address = accounts.add()
-    cert_height = 3
+    cert_position = 3
     authorize_origin(dummy_address, admin, topos_executable)
     topos_core_contract_B.verifyCertificate(
-        get_encoded_cert_params(c.CERT_ID, cert_height), {"from": admin}
+        get_encoded_cert_params(c.CERT_ID, cert_position), {"from": admin}
     )
     data = get_call_contract_data(dummy_address, c.DESTINATION_SUBNET_ID)
-    # should revert since the cert height < min cert height
+    # should revert since the cert position < min cert position
     with brownie.reverts():
         topos_executable.execute(
             c.CERT_ID, data, c.DUMMY_DATA, {"from": admin}
@@ -97,7 +97,7 @@ def test_execute_with_token_reverts_on_unverified_cert_id(
     invalid_cert_id = brownie.convert.to_bytes("0xdead", "bytes")
     dummy_address = accounts.add()
     topos_core_contract_B.verifyCertificate(
-        get_encoded_cert_params(c.CERT_ID, c.CERT_HEIGHT), {"from": admin}
+        get_encoded_cert_params(c.CERT_ID, c.CERT_POSITION), {"from": admin}
     )
     data = get_call_contract_with_token_data(
         dummy_address, c.DESTINATION_SUBNET_ID
@@ -115,7 +115,7 @@ def test_execute_with_token_reverts_on_false_destination_id(
     invalid_destination_subnet_id = brownie.convert.to_bytes("0x03", "bytes32")
     dummy_address = accounts.add()
     topos_core_contract_B.verifyCertificate(
-        get_encoded_cert_params(c.CERT_ID, c.CERT_HEIGHT), {"from": admin}
+        get_encoded_cert_params(c.CERT_ID, c.CERT_POSITION), {"from": admin}
     )
     data = get_call_contract_with_token_data(
         dummy_address, invalid_destination_subnet_id
@@ -133,7 +133,7 @@ def test_execute_with_token_reverts_on_contract_call_already_executed(
     dummy_address = accounts.add()
     authorize_origin(dummy_address, admin, topos_executable)
     topos_core_contract_B.verifyCertificate(
-        get_encoded_cert_params(c.CERT_ID, c.CERT_HEIGHT), {"from": admin}
+        get_encoded_cert_params(c.CERT_ID, c.CERT_POSITION), {"from": admin}
     )
     data = get_call_contract_with_token_data(
         dummy_address, c.DESTINATION_SUBNET_ID
@@ -148,19 +148,19 @@ def test_execute_with_token_reverts_on_contract_call_already_executed(
         )
 
 
-def test_execute_with_token_reverts_on_cert_height_lower_than_min_height(
+def test_execute_with_token_reverts_on_cert_position_lower_than_min_position(
     accounts, admin, topos_core_contract_B, topos_executable
 ):
     dummy_address = accounts.add()
-    cert_height = 3
+    cert_position = 3
     authorize_origin(dummy_address, admin, topos_executable)
     topos_core_contract_B.verifyCertificate(
-        get_encoded_cert_params(c.CERT_ID, cert_height), {"from": admin}
+        get_encoded_cert_params(c.CERT_ID, cert_position), {"from": admin}
     )
     data = get_call_contract_with_token_data(
         dummy_address, c.DESTINATION_SUBNET_ID
     )
-    # should revert since the cert height < min cert height
+    # should revert since the cert position < min cert position
     with brownie.reverts():
         topos_executable.executeWithToken(
             c.CERT_ID, data, c.DUMMY_DATA, {"from": admin}
@@ -173,7 +173,7 @@ def authorize_origin(sender, spender, topos_executable):
         c.ORIGIN_SUBNET_ID,
         sender,
         get_selector_hash(),
-        c.MINIMUM_CERT_HEIGHT,
+        c.MINIMUM_CERT_POSITION,
         {"from": spender},
     )
 
@@ -206,8 +206,8 @@ def get_call_contract_with_token_data(addr, subnet_id):
     ]
 
 
-def get_encoded_cert_params(cert_id, cert_height):
-    return eth_abi.encode(["bytes", "uint256"], [cert_id, cert_height])
+def get_encoded_cert_params(cert_id, cert_position):
+    return eth_abi.encode(["bytes", "uint256"], [cert_id, cert_position])
 
 
 def get_payload_hash():


### PR DESCRIPTION
Resolves [TP-282](https://linear.app/toposware/issue/TP-282/rename-topos-smart-contracts-certificate-height-to-position)

Signed-off-by: Jawad Tariq <sjcool420@hotmail.co.uk>