### PR TITLE
chore: remove `payloadHash` as a field

### DIFF
--- a/brownie/contracts/executables/ToposExecutable.sol
+++ b/brownie/contracts/executables/ToposExecutable.sol
@@ -188,7 +188,6 @@ contract ToposExecutable is IToposExecutable {
                     contractCallData.sourceContractAddr,
                     contractCallData.targetSubnetId,
                     contractCallData.targetContractAddr,
-                    contractCallData.payloadHash,
                     contractCallData.payload,
                     contractCallData.selector
                 )
@@ -209,7 +208,6 @@ contract ToposExecutable is IToposExecutable {
                     contractCallWithTokenData.sourceContractAddr,
                     contractCallWithTokenData.targetSubnetId,
                     contractCallWithTokenData.targetContractAddr,
-                    contractCallWithTokenData.payloadHash,
                     contractCallWithTokenData.payload,
                     contractCallWithTokenData.symbol,
                     contractCallWithTokenData.amount,

--- a/brownie/contracts/topos-core/ToposCoreContract.sol
+++ b/brownie/contracts/topos-core/ToposCoreContract.sol
@@ -170,14 +170,7 @@ contract ToposCoreContract is IToposCoreContract, AdminMultisigBase {
         address targetContractAddr,
         bytes calldata payload
     ) external {
-        emit ContractCall(
-            _networkSubnetId,
-            msg.sender,
-            targetSubnetId,
-            targetContractAddr,
-            keccak256(payload),
-            payload
-        );
+        emit ContractCall(_networkSubnetId, msg.sender, targetSubnetId, targetContractAddr, payload);
     }
 
     function callContractWithToken(
@@ -193,7 +186,6 @@ contract ToposCoreContract is IToposCoreContract, AdminMultisigBase {
             msg.sender,
             targetSubnetId,
             targetContractAddr,
-            keccak256(payload),
             payload,
             symbol,
             amount

--- a/brownie/interfaces/IToposCoreContract.sol
+++ b/brownie/interfaces/IToposCoreContract.sol
@@ -48,7 +48,6 @@ interface IToposCoreContract {
         address sourceContractAddr,
         subnetId targetSubnetId,
         address targetContractAddr,
-        bytes32 indexed payloadHash,
         bytes payload
     );
 
@@ -57,7 +56,6 @@ interface IToposCoreContract {
         address sourceContractAddr,
         subnetId targetSubnetId,
         address targetContractAddr,
-        bytes32 indexed payloadHash,
         bytes payload,
         string symbol,
         uint256 amount

--- a/brownie/interfaces/IToposExecutable.sol
+++ b/brownie/interfaces/IToposExecutable.sol
@@ -24,7 +24,6 @@ interface IToposExecutable {
         address sourceContractAddr;
         subnetId targetSubnetId;
         address targetContractAddr;
-        bytes32 payloadHash;
         bytes payload;
         bytes32 selector; // keccak256 hash of a function name eg. keccak256("executeContractCall")
     }
@@ -35,7 +34,6 @@ interface IToposExecutable {
         address sourceContractAddr;
         subnetId targetSubnetId;
         address targetContractAddr;
-        bytes32 payloadHash;
         bytes payload;
         string symbol;
         uint256 amount;

--- a/brownie/tests/integration/test_xs_contract_call.py
+++ b/brownie/tests/integration/test_xs_contract_call.py
@@ -160,7 +160,6 @@ def approve_and_execute_on_receiving_subnet(
     source_contract_addr = contract_call_event["sourceContractAddr"]
     target_subnet_id = contract_call_event["targetSubnetId"]
     target_contract_addr = contract_call_event["targetContractAddr"]
-    payload_hash = contract_call_event["payloadHash"]
     payload = contract_call_event["payload"]
 
     # set the admin manually
@@ -181,7 +180,6 @@ def approve_and_execute_on_receiving_subnet(
         source_contract_addr,
         target_subnet_id,
         target_contract_addr,
-        payload_hash,
         payload,
         selector,
     ]

--- a/brownie/tests/unit/test_topos_core_contract.py
+++ b/brownie/tests/unit/test_topos_core_contract.py
@@ -1,5 +1,4 @@
 import brownie
-from Crypto.Hash import keccak
 import eth_abi
 
 import const as c
@@ -591,14 +590,11 @@ def test_call_contract_emits_event(accounts, alice, topos_core_contract_A):
         c.DUMMY_DATA,
         {"from": alice},
     )
-    k = keccak.new(digest_bits=256)
-    k.update(c.DUMMY_DATA)
     assert tx.events["ContractCall"].values() == [
         brownie.convert.datatypes.HexString(c.SOURCE_SUBNET_ID, "bytes32"),
         alice.address,
         brownie.convert.datatypes.HexString(c.TARGET_SUBNET_ID, "bytes32"),
         target_contract_addr.address,
-        "0x" + k.hexdigest(),  # payload hash
         brownie.convert.datatypes.HexString(c.DUMMY_DATA, "bytes"),
     ]
 
@@ -631,14 +627,11 @@ def test_call_contract_with_token_emits_event(
         c.SEND_AMOUNT,
         {"from": alice},
     )
-    k = keccak.new(digest_bits=256)
-    k.update(c.DUMMY_DATA)
     assert tx.events["ContractCallWithToken"].values() == [
         brownie.convert.datatypes.HexString(c.SOURCE_SUBNET_ID, "bytes32"),
         alice.address,
         brownie.convert.datatypes.HexString(c.TARGET_SUBNET_ID, "bytes32"),
         target_contract_addr.address,
-        "0x" + k.hexdigest(),  # payload hash
         brownie.convert.datatypes.HexString(c.DUMMY_DATA, "bytes"),
         c.TOKEN_SYMBOL_X,
         c.SEND_AMOUNT,

--- a/brownie/tests/unit/test_topos_executable.py
+++ b/brownie/tests/unit/test_topos_executable.py
@@ -179,7 +179,6 @@ def get_call_contract_data(addr, subnet_id):
         addr,  # source_contract_addr
         subnet_id,
         addr,  # target_contract_addr
-        get_payload_hash(),
         c.PAYLOAD,
         get_selector_hash(),
     ]
@@ -192,7 +191,6 @@ def get_call_contract_with_token_data(addr, subnet_id):
         addr,  # source_contract_addr
         subnet_id,
         addr,  # target_contract_addr
-        get_payload_hash(),
         c.PAYLOAD,
         c.TOKEN_SYMBOL_X,
         c.SEND_AMOUNT,
@@ -202,12 +200,6 @@ def get_call_contract_with_token_data(addr, subnet_id):
 
 def get_encoded_cert_params(cert_id, cert_position):
     return eth_abi.encode(["bytes", "uint256"], [cert_id, cert_position])
-
-
-def get_payload_hash():
-    k = keccak.new(digest_bits=256)
-    k.update(c.PAYLOAD)
-    return "0x" + k.hexdigest()
 
 
 def get_selector_hash():


### PR DESCRIPTION
Signed-off-by: Jawad Tariq <sjcool420@hotmail.co.uk>

# Description

This removes `payloadHash` field from `ContractCallData` and `ContractCallWithTokenData`.

Resolves TP-406
