### PR TITLE
feat: add CR storage for cert registration

### DIFF
--- a/brownie/interfaces/IToposCoreContract.sol
+++ b/brownie/interfaces/IToposCoreContract.sol
@@ -10,7 +10,6 @@ interface IToposCoreContract {
     \**********/
 
     error CertNotPresent();
-    error CertAlreadyPresent();
     error BurnFailed(string symbol);
     error ExceedDailyMintLimit(string symbol);
     error InvalidAmount();
@@ -31,7 +30,6 @@ interface IToposCoreContract {
     struct Certificate {
         CertificateId id;
         uint256 position;
-        bool isPresent;
     }
 
     /**********\
@@ -131,6 +129,12 @@ interface IToposCoreContract {
     function getStorageCert(CertificateId certId) external view returns (Certificate memory);
 
     function tokenDeployer() external view returns (address);
+
+    function certificateExists(CertificateId certId) external view returns (bool);
+
+    function getCertificateCount() external view returns (uint256);
+
+    function getCertIdAtIndex(uint256 index) external view returns (CertificateId);
 
     /*******************\
     |* Admin Functions *|

--- a/brownie/tests/unit/test_topos_core_contract.py
+++ b/brownie/tests/unit/test_topos_core_contract.py
@@ -13,15 +13,34 @@ def test_push_certificate_reverts_on_already_stored_certificate(
         push_dummy_cert(admin, topos_core_contract_A)
 
 
+def test_get_certificate_count_returns_count(admin, topos_core_contract_A):
+    count = 1
+    push_dummy_cert(admin, topos_core_contract_A)
+    assert topos_core_contract_A.getCertificateCount({"from": admin}) == count
+
+
 def test_push_certificate_emits_event(admin, topos_core_contract_A):
     tx = push_dummy_cert(admin, topos_core_contract_A)
+    assert (
+        topos_core_contract_A.certificateExists(c.CERT_ID, {"from": admin})
+        is True
+    )
     assert tx.events["CertStored"].values() == [c.CERT_BYTES]
+
+
+def test_get_cert_id_at_index_returns_cert_id(admin, topos_core_contract_A):
+    index = 0  # only one imported certificate
+    push_dummy_cert(admin, topos_core_contract_A)
+    assert (
+        topos_core_contract_A.getCertIdAtIndex(index, {"from": admin})
+        == c.CERT_BYTES
+    )
 
 
 def test_set_token_daily_mint_limits_reverts_on_mismatch_symbol_length(
     admin, topos_core_contract_A
 ):
-    # symbol and limit array lenghts should be 1:1 ratio
+    # symbol and limit array lengths should be 1:1 ratio
     symbols = [c.TOKEN_SYMBOL_X, c.TOKEN_SYMBOL_Y]
     mint_limits = [c.MINT_AMOUNT]
     with brownie.reverts():


### PR DESCRIPTION
# Description
This PR adds the CR storage pattern for pushing certificates on the target subnet via the `ToposCoreContract.sol`.

Resolves TP-420

## Additions and Changes
- Adapt to changes when pushing the certificate in `pushCertificate()`
- Adds `certificateExists()` -> function to check if a certificate is already pushed on a subnet or not
- Adds `getCertificateCount()` -> function to get the total number of pushed certificates
- Adds `getCertIdAtIndex()` -> function to get a `certId` at given `Index`

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works

Signed-off-by: Jawad Tariq <sjcool420@hotmail.co.uk>
