### PR TITLE
feat: add `chainId` to `SubnetRegistrator`

### DIFF
--- a/brownie/contracts/topos-core/SubnetRegistrator.sol
+++ b/brownie/contracts/topos-core/SubnetRegistrator.sol
@@ -12,6 +12,7 @@ contract SubnetRegistrator {
         string logoURL;
         string name;
         string currencySymbol;
+        uint256 chainId;
     }
 
     /// @notice Set of subnet IDs
@@ -50,12 +51,14 @@ contract SubnetRegistrator {
     /// @param name name of a subnet
     /// @param subnetId FROST public key of a subnet
     /// @param currencySymbol currencySymbol for a subnet currency
+    /// @param chainId subnet network ID
     function registerSubnet(
         string calldata endpoint,
         string calldata logoURL,
         string calldata name,
         SubnetId subnetId,
-        string calldata currencySymbol
+        string calldata currencySymbol,
+        uint256 chainId
     ) public {
         subnetSet.insert(SubnetId.unwrap(subnetId));
         Subnet storage subnet = subnets[subnetId];
@@ -63,6 +66,7 @@ contract SubnetRegistrator {
         subnet.logoURL = logoURL;
         subnet.name = name;
         subnet.currencySymbol = currencySymbol;
+        subnet.chainId = chainId;
         emit NewSubnetRegistered(subnetId);
     }
 

--- a/brownie/tests/unit/const.py
+++ b/brownie/tests/unit/const.py
@@ -5,6 +5,7 @@ APPROVE_AMOUNT = 10
 CERT_BYTES = "0xdeaf"
 CERT_POSITION = 5
 CERT_ID = brownie.convert.to_bytes(CERT_BYTES, "bytes32")
+CHAIN_ID = 1
 DAILY_MINT_LIMIT = 100
 TARGET_SUBNET_ID = brownie.convert.to_bytes("0x02", "bytes32")
 DUMMY_DATA = brownie.convert.to_bytes("0x00", "bytes")

--- a/brownie/tests/unit/test_subnet_registrator.py
+++ b/brownie/tests/unit/test_subnet_registrator.py
@@ -62,5 +62,6 @@ def register_subnet(alice, subnet_registrator):
         c.SUBNET_NAME,
         c.SUBNET_ID,
         c.SUBNET_CURRENCY_SYMBOL,
+        c.CHAIN_ID,
         {"from": alice},
     )


### PR DESCRIPTION
# Description

This PR adds the subnet network id `chainId` as an additional field for the `Subnet` struct.

Resolves TP-425

## Additions and Changes

- Adds `chainId` in the `SubnetRegistrator` contract

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works

Signed-off-by: Jawad Tariq <sjcool420@hotmail.co.uk>