### PR TITLE
feat: return contract address in deploy2 script

### DIFF
--- a/brownie/scripts/deploy.js
+++ b/brownie/scripts/deploy.js
@@ -42,7 +42,7 @@ const main = async function (
     return;
   }
 
-  axelarUtils
+  return axelarUtils
     .deployContractConstant(
       CONST_ADDRESS_DEPLOYER_ADDR,
       wallet,
@@ -57,6 +57,8 @@ const main = async function (
           contract.address
         }`,
       );
+
+      return contract.address;
     })
     .catch(console.error);
 };


### PR DESCRIPTION
# Description

This PR updates the `deploy2` npm script to have it return the address of the deployed contract. This is very useful when chaining multiple dependent `deploy2` executions.

## Additions and Changes

### New feature (non-breaking change which adds functionality)

- Returns the promise which resolves to the deployed contract address in the `deploy.js` script

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
