### PR TITLE
feat: add script to deploy full topos-msg-protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,26 @@ Example:
 $ npm run deploy ToposCoreContract 0x4897d0802e611AF187db47C7648e8B0Ef759e3aa 1
 ```
 
-## Deployment with DEPLOY2
+## Deployment of a single contract with CREATE2
 
-A NodeJS script is made available to deploy contracts with `DEPLOY2`, i.e., with constant addresses. The script is to be used with a deployed instance of `ConstAddressDeployer`. See an example below:
+A NodeJS script is made available to deploy contracts with `CREATE2`, i.e., with constant addresses. The script is to be used with a deployed instance of `ConstAddressDeployer`. See an example below:
 
 ```
 npm run deploy2 http://myChainRPCEndpoint myCompiledContract.json MySecretSalt ACustomGasLimit|null MyConstructorArg AnotherConstructorArg
 # npm run deploy2 http://127.0.0.1:8545 brownie/build/contracts/ToposCoreContract.json $TOPOS_CORE_SALT 2000000 0xF121424e3F7d73fCD79DcBCA67E8F10BeBE67b00 0x3100000000000000000000000000000000000000000000000000000000000000
+```
+
+## Deployment of the full Topos Messaging Protocol
+
+To deploy the full Topos Messaging Protocol, another `deploy2:topos-msg-protocol` npm script is available. This scripts deploys the following contracts:
+
+- `TokenDeployer` with constant address
+- `ToposCore`
+- `ToposCoreProxy` with constant address
+
+```
+npm run deploy2:topos-msg-protocol http://myChainRPCEndpoint
+# npm run deploy2:topos-msg-protocol http://127.0.0.1:8545
 ```
 
 ## Docker

--- a/brownie/scripts/deploy-topos-msg-protocol.js
+++ b/brownie/scripts/deploy-topos-msg-protocol.js
@@ -1,0 +1,114 @@
+const axelarUtils = require('@axelar-network/axelar-gmp-sdk-solidity');
+const ethers = require('ethers');
+
+const tokenDeployerJSON = require('../build/contracts/TokenDeployer.json');
+const toposCoreJSON = require('../build/contracts/ToposCoreContract.json');
+const toposCoreProxyJSON = require('../build/contracts/ToposCoreContractProxy.json');
+
+const CONST_ADDRESS_DEPLOYER_ADDR =
+  '0x0000000000000000000000000000000000001110';
+
+const main = async function (endpoint) {
+  const provider = new ethers.providers.JsonRpcProvider(endpoint);
+  const privateKey = process.env.PRIVATE_KEY;
+  const tokenDeployerSalt = process.env.TOKEN_DEPLOYER_SALT;
+  const toposCoreSalt = process.env.TOPOS_CORE_SALT;
+
+  if (!privateKey || ethers.utils.isHexString(privateKey, 32)) {
+    console.error('ERROR: Please provide a valid private key! (PRIVATE_KEY)');
+    return;
+  }
+
+  if (!tokenDeployerSalt) {
+    console.error(
+      'ERROR: Please provide a salt for TokenDeployer! (TOKEN_DEPLOYER_SALT)',
+    );
+    return;
+  }
+
+  if (!toposCoreSalt) {
+    console.error(
+      'ERROR: Please provide a salt for ToposCore! (TOKEN_DEPLOYER_SALT)',
+    );
+    return;
+  }
+
+  const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
+
+  console.info(`Deploying TokenDeployer with constant address...`);
+
+  const tokenDeployerAddress = await deployConstAddress(
+    wallet,
+    tokenDeployerJSON,
+    tokenDeployerSalt,
+  );
+
+  console.info(
+    `Successfully deployed TokenDeployer at ${tokenDeployerAddress}!\n`,
+  );
+
+  console.info(`Deploying ToposCore...`);
+
+  const toposCoreFactory = new ethers.ContractFactory(
+    toposCoreJSON.abi,
+    toposCoreJSON.bytecode,
+    wallet,
+  );
+
+  const toposCoreAddress = await toposCoreFactory
+    .deploy(
+      tokenDeployerAddress,
+      '0x3100000000000000000000000000000000000000000000000000000000000000',
+    )
+    .then(async (contract) => {
+      await contract.deployTransaction.wait();
+      return contract.address;
+    });
+
+  console.info(`Successfully deployed ToposCore at ${toposCoreAddress}!\n`);
+
+  console.info(`Deploying ToposCoreProxy with constant address...`);
+
+  const params = ethers.utils.defaultAbiCoder.encode(
+    ['address[]', 'uint256'],
+    [[wallet.address], 1],
+  );
+
+  const toposCoreProxyAddress = await deployConstAddress(
+    wallet,
+    toposCoreProxyJSON,
+    toposCoreSalt,
+    [toposCoreAddress, params],
+    4_000_000,
+  );
+
+  console.info(
+    `Successfully deployed ToposCoreProxy at ${toposCoreProxyAddress}!\n`,
+  );
+};
+
+const deployConstAddress = function (
+  wallet,
+  contractJson,
+  salt,
+  args,
+  gasLimit = 0,
+) {
+  return axelarUtils
+    .deployContractConstant(
+      CONST_ADDRESS_DEPLOYER_ADDR,
+      wallet,
+      contractJson,
+      salt,
+      args,
+      gasLimit === 0 ? null : gasLimit,
+    )
+    .then((contract) => contract.address)
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+};
+
+const args = process.argv.slice(2);
+main(...args);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "coverage": "brownie test -C",
     "deploy": "brownie run deploy.py main",
     "deploy2": "node brownie/scripts/deploy.js",
+    "deploy2:topos-msg-protocol": "node brownie/scripts/deploy-topos-msg-protocol.js",
     "install": "npm run install:flake8 && npm run install:black && npm run install:eth_abi && npm run install:Crypto",
     "install:Crypto": "pip3 install pycryptodome",
     "install:black": "pip3 install black",


### PR DESCRIPTION
# Description

This PR adds to the list of scripts a new script to deploy the full Topos Messaging Protocol. We now have two scripts:
- `deploy.js`: Deploy a single contract to a network, with args and gas limit
- `deploy-topos-msg-protocol.js`: Deploy the full Topos Messaging Protocol (`TokenDeployer`, `ToposCore`, `ToposCoreProxy`)

The rationale behind the new script is that deploying the full Topos Messaging Protocol with `deploy.js` started to be challenging.

## Additions and Changes

### New feature (non-breaking change which adds functionality)

- Adds a `deploy-topos-msg-protocol.js` script to deploy the full Topos Messaging Protocol
- Adds a `deploy2:topos-msg-protocol` npm script to use the above script in a simple way

Usage:
```shell
$ npm run deploy2:topos-msg-protocol <endpoint>
# npm run deploy2:topos-msg-protocol http://localhost:10002
```

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
