### PR TITLE
chore: refactor certificate storage impl

### DIFF
--- a/brownie/contracts/topos-core/ToposCore.sol
+++ b/brownie/contracts/topos-core/ToposCore.sol
@@ -25,7 +25,7 @@ contract ToposCore is IToposCore, AdminMultisigBase {
 
     /// @notice Mapping to store certificates
     /// @dev CertificateId(bytes32) => certificate(bytes)
-    mapping(CertificateId => Certificate) certificateStorage;
+    mapping(CertificateId => Certificate) public certificates;
 
     /// @notice Mapping to store Tokens
     /// @dev TokenKey(bytes32) => Token
@@ -153,7 +153,7 @@ contract ToposCore is IToposCore, AdminMultisigBase {
     function pushCertificate(bytes memory certBytes) external {
         (CertificateId certId, uint256 certPosition) = abi.decode(certBytes, (CertificateId, uint256));
         certificateSet.insert(CertificateId.unwrap(certId));
-        Certificate storage newCert = certificateStorage[certId];
+        Certificate storage newCert = certificates[certId];
         newCert.id = certId;
         newCert.position = certPosition;
         emit CertStored(certId);
@@ -256,7 +256,7 @@ contract ToposCore is IToposCore, AdminMultisigBase {
 
     function verifyContractCallData(CertificateId certId, SubnetId targetSubnetId) public override returns (uint256) {
         if (!certificateExists(certId)) revert CertNotPresent();
-        Certificate memory storedCert = getStorageCert(certId);
+        Certificate memory storedCert = certificates[certId];
         if (!_validateTargetSubnetId(targetSubnetId)) revert InvalidSubnetId();
         emit ContractCallDataVerified(storedCert.position);
         return storedCert.position;
@@ -276,10 +276,6 @@ contract ToposCore is IToposCore, AdminMultisigBase {
 
     function getCertIdAtIndex(uint256 index) public view returns (CertificateId) {
         return CertificateId.wrap(certificateSet.keyAtIndex(index));
-    }
-
-    function getStorageCert(CertificateId certId) public view returns (Certificate memory) {
-        return certificateStorage[certId];
     }
 
     function tokenDailyMintLimit(string memory symbol) public view override returns (uint256) {

--- a/brownie/interfaces/IToposCore.sol
+++ b/brownie/interfaces/IToposCore.sol
@@ -131,7 +131,7 @@ interface IToposCore {
 
     function admins(uint256 epoch) external view returns (address[] memory);
 
-    function getStorageCert(CertificateId certId) external view returns (Certificate memory);
+    function certificates(CertificateId certId) external view returns (CertificateId, uint256);
 
     function tokenDeployer() external view returns (address);
 


### PR DESCRIPTION
# Description

This PR refactors the CRUD storage implementation for the certificate storage.

Fixes TP-446

## Additions and Changes

- Removes the unnecessary `getStorageCert` getter function
- Renames `certificateStorage` to `certificates`
- Exposes the default getter for the `certificates` in the Topos Core interface

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works

Signed-off-by: Jawad Tariq <sjcool420@hotmail.co.uk>