### PR TITLE
chore: log already deployed contract address

### DIFF
--- a/brownie/scripts/deploy-topos-msg-protocol.js
+++ b/brownie/scripts/deploy-topos-msg-protocol.js
@@ -83,7 +83,9 @@ const main = async function (endpoint, _sequencerPrivateKey) {
   );
 
   if (tokenDeployerCode !== '0x') {
-    console.info(`TokenDeployer is already deployed!`);
+    console.info(
+      `TokenDeployer is already deployed! (${existingTokenDeployerAddress})`,
+    );
   } else {
     console.info(`Deploying TokenDeployer with constant address...`);
 
@@ -110,7 +112,9 @@ const main = async function (endpoint, _sequencerPrivateKey) {
   const toposCoreCode = await provider.getCode(existingToposCoreAddress);
 
   if (toposCoreCode !== '0x') {
-    console.info(`ToposCore is already deployed!`);
+    console.info(
+      `ToposCore is already deployed! (${existingToposCoreAddress})`,
+    );
   } else {
     console.info(`Deploying ToposCore...`);
 
@@ -144,7 +148,9 @@ const main = async function (endpoint, _sequencerPrivateKey) {
   );
 
   if (toposCoreProxyCode !== '0x') {
-    console.info(`ToposCoreProxy is already deployed!`);
+    console.info(
+      `ToposCoreProxy is already deployed! (${existingToposCoreProxyAddress})`,
+    );
   } else {
     console.info(`Deploying ToposCoreProxy with constant address...`);
 


### PR DESCRIPTION
# Description

Since a recent update, the Topos Messaging Protocol deploy script verifies before deploying whether contracts already exist. In that case, a simple `Already deployed` message is logged, but the actual address of that contract is not exposed, which can pose problems when stopping and restarting the chain (one would lose older logs and hence the said address).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
