### PR TITLE
fix: use fixed nodejs version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-slim as base
+FROM node:18.15.0-slim as base
 WORKDIR /usr/src/app
 COPY package*.json .
 RUN npm install


### PR DESCRIPTION
# Description

Moving from `brownie` to `hardhat` made our docker images unstable: they would not contain compiled contracts. After we investigated the problem and noticed it was reproducible with a basic `hardhat` project, we created an issue on `hardhat`'s repo.

The problem, as described by their contributors, is coming from nodejs.

In docker, we were using the `lts-slim` tag for the base nodejs image.

This PR introduces a fixed version with the `18.15.0-slim` tag.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
