### PR TITLE
chore: remove unsupported external txn type

### DIFF
--- a/contracts/interfaces/IToposMessaging.sol
+++ b/contracts/interfaces/IToposMessaging.sol
@@ -19,9 +19,8 @@ interface IToposMessaging {
     }
 
     enum TokenType {
-        InternalBurnable,
         InternalBurnableFrom,
-        External
+        External // Not supported yet
     }
 
     event TokenDailyMintLimitUpdated(string symbol, uint256 limit);
@@ -47,13 +46,12 @@ interface IToposMessaging {
     error InvalidSubnetId();
     error InvalidTokenDeployer();
     error InvalidToposCore();
-    error MintFailed(string symbol);
     error TokenAlreadyExists(string symbol);
-    error TokenContractDoesNotExist(address token);
     error TokenDeployFailed(string symbol);
     error TokenDoesNotExist(string symbol);
     error TransferAlreadyExecuted();
     error UnsupportedProofKind();
+    error UnsupportedTokenType();
 
     function deployToken(bytes calldata params) external;
 

--- a/contracts/topos-core/ToposMessaging.sol
+++ b/contracts/topos-core/ToposMessaging.sol
@@ -73,11 +73,8 @@ contract ToposMessaging is IToposMessaging, EternalStorage {
 
             _setTokenType(symbol, TokenType.InternalBurnableFrom);
         } else {
-            // If token address is specified, ensure that there is a contact at the specified address.
-            if (tokenAddress.code.length == uint256(0)) revert TokenContractDoesNotExist(tokenAddress);
-
-            // Mark that this symbol is an external token, which is needed to differentiate between operations on mint and burn.
-            _setTokenType(symbol, TokenType.External);
+            revert UnsupportedTokenType();
+            // _setTokenType(symbol, TokenType.External);
         }
 
         _setTokenAddress(symbol, tokenAddress);
@@ -243,11 +240,7 @@ contract ToposMessaging is IToposMessaging, EternalStorage {
         bool burnSuccess;
 
         if (tokenType == TokenType.External) {
-            burnSuccess = _callERC20Token(
-                tokenAddress,
-                abi.encodeWithSelector(IERC20.transferFrom.selector, sender, address(this), amount)
-            );
-            if (!burnSuccess) revert BurnFailed(symbol);
+            revert UnsupportedTokenType();
         } else if (tokenType == TokenType.InternalBurnableFrom) {
             burnSuccess = _callERC20Token(
                 tokenAddress,
@@ -291,12 +284,7 @@ contract ToposMessaging is IToposMessaging, EternalStorage {
         _setTokenDailyMintAmount(symbol, tokenDailyMintAmount(symbol) + amount);
 
         if (_getTokenType(symbol) == TokenType.External) {
-            bool success = _callERC20Token(
-                tokenAddress,
-                abi.encodeWithSelector(IERC20.transfer.selector, account, amount)
-            );
-
-            if (!success) revert MintFailed(symbol);
+            revert UnsupportedTokenType();
         } else {
             IBurnableMintableCappedERC20(tokenAddress).mint(account, amount);
         }


### PR DESCRIPTION
# Description

This removes any support for the external token types from the `ToposMessaging.sol` smart contract.

Fixes TP-540

## Additions and Changes

- Removed support for "External" ERC20 token type in `ToposMessaging.sol` and its interface

## Breaking changes

Trying to deploy an external token will revert the transaction

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
