### PR TITLE
chore: remove `setTokenDailyMintLimits` function

### DIFF
--- a/contracts/interfaces/IToposMessaging.sol
+++ b/contracts/interfaces/IToposMessaging.sol
@@ -64,9 +64,6 @@ interface IToposMessaging {
 
     function sendToken(SubnetId targetSubnetId, address receiver, address tokenAddress, uint256 amount) external;
 
-    // TODO: decide what to do with this function
-    // function setTokenDailyMintLimits(string[] calldata symbols, uint256[] calldata limits) external;
-
     function validateMerkleProof(bytes memory proofBlob, bytes32 txHash, bytes32 txRoot) external returns (bool);
 
     function getTokenByAddress(address tokenAddress) external view returns (Token memory token);

--- a/contracts/topos-core/ToposMessaging.sol
+++ b/contracts/topos-core/ToposMessaging.sol
@@ -152,26 +152,6 @@ contract ToposMessaging is IToposMessaging, EternalStorage {
         );
     }
 
-    // TODO: decide what to do with this function
-    /// @notice Set token daily mint limit
-    /// @param symbols Symbols of tokens
-    /// @param limits Daily mint limits of tokens
-    // function setTokenDailyMintLimits(
-    //     string[] calldata symbols,
-    //     uint256[] calldata limits
-    // ) external override {
-    //     if (symbols.length != limits.length) revert InvalidSetDailyMintLimitsParams();
-
-    //     for (uint256 i = 0; i < symbols.length; i++) {
-    //         string memory symbol = symbols[i];
-    //         uint256 limit = limits[i];
-
-    //         if (getTokenBySymbol(symbol).tokenAddress == address(0)) revert TokenDoesNotExist(symbol);
-
-    //         _setTokenDailyMintLimit(symbol, limit);
-    //     }
-    // }
-
     /// @notice Gets the token by address
     /// @param tokenAddress Address of token contract
     function getTokenByAddress(address tokenAddress) public view returns (Token memory token) {

--- a/test/topos-core/ToposMessaging.test.ts
+++ b/test/topos-core/ToposMessaging.test.ts
@@ -226,42 +226,6 @@ describe('ToposMessaging', () => {
     })
   })
 
-  //   describe('setTokenDailyMintLimits', () => {
-  //     it('reverts if the token symbol length mismatch mint limit length', async () => {
-  //       const { toposMessaging } = await loadFixture(deployToposMessagingFixture)
-  //       const symbols = ['ABC', 'XYZ']
-  //       const mintLimits = [1]
-  //       await expect(
-  //         toposMessaging.setTokenDailyMintLimits(symbols, mintLimits)
-  //       ).to.be.revertedWithCustomError(
-  //         toposMessaging,
-  //         'InvalidSetDailyMintLimitsParams'
-  //       )
-  //     })
-
-  //     it('revert if the token symbol does not exist', async () => {
-  //       const { toposMessaging } = await loadFixture(deployToposMessagingFixture)
-  //       const symbols = ['ABC']
-  //       const mintLimits = [1]
-  //       await expect(toposMessaging.setTokenDailyMintLimits(symbols, mintLimits))
-  //         .to.be.revertedWithCustomError(toposMessaging, 'TokenDoesNotExist')
-  //         .withArgs('ABC')
-  //     })
-
-  //     it('emits a token daily mint limits set event', async () => {
-  //       const { defaultToken, toposMessaging } = await loadFixture(
-  //         deployToposMessagingFixture
-  //       )
-  //       await toposMessaging.deployToken(defaultToken)
-  //       const symbols = [tc.TOKEN_SYMBOL_X]
-  //       const mintLimits = [1]
-  //       const tx = await toposMessaging.setTokenDailyMintLimits(symbols, mintLimits)
-  //       await expect(tx)
-  //         .to.emit(toposMessaging, 'TokenDailyMintLimitUpdated')
-  //         .withArgs(tc.TOKEN_SYMBOL_X, 1)
-  //     })
-  //   })
-
   describe('executeAssetTransfer', () => {
     it('deploys a token with zero mint limit', async () => {
       const {


### PR DESCRIPTION
# Description

This removes the `setTokenDailyMintLimits` function as it required an access control modifier which was removed with the split of the `ToposCore` contract. The behaviour, for now, is that the token deployer sets the daily mint limit for his/her token at the moment of deploying the token.

## Additions and Changes

- Removed the `setTokenDailyMintLimits` function from `ToposMessaging` contract
- Removed the `setTokenDailyMintLimits` function from the interface `IToposMessaging`
- Removed references from the unit test

## Breaking changes

Once the daily mint limit is set it cannot be changed.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
