### PR TITLE
feat: add general cross-subnet msg event

### DIFF
--- a/contracts/interfaces/IToposCore.sol
+++ b/contracts/interfaces/IToposCore.sol
@@ -24,11 +24,15 @@ interface IToposCore {
 
     event CertStored(CertificateId certId, bytes32 txRoot);
 
+    event CrossSubnetMessageSent(SubnetId targetSubnetId);
+
     event Upgraded(address indexed implementation);
 
     error InvalidCodeHash();
     error NotProxy();
     error SetupFailed();
+
+    function emitCrossSubnetMessage(SubnetId targetSubnetId) external;
 
     function pushCertificate(bytes calldata certBytes, uint256 position) external;
 

--- a/contracts/interfaces/IToposMessaging.sol
+++ b/contracts/interfaces/IToposMessaging.sol
@@ -27,15 +27,6 @@ interface IToposMessaging {
 
     event TokenDeployed(string symbol, address tokenAddress);
 
-    event TokenSent(
-        address indexed sender,
-        SubnetId sourceSubnetId,
-        SubnetId targetSubnetId,
-        address receiver,
-        address tokenAddress,
-        uint256 amount
-    );
-
     error BurnFailed(address tokenAddress);
     error CertNotPresent();
     error ExceedDailyMintLimit(address tokenAddress);

--- a/contracts/topos-core/ToposCore.sol
+++ b/contracts/topos-core/ToposCore.sol
@@ -121,6 +121,12 @@ contract ToposCore is IToposCore, AdminMultisigBase {
         _setAdmins(newAdminEpoch, adminAddresses, newAdminThreshold);
     }
 
+    /// @notice Emits an event to signal a cross subnet message has been sent
+    /// @param targetSubnetId The subnet ID of the target subnet
+    function emitCrossSubnetMessage(SubnetId targetSubnetId) external {
+        emit CrossSubnetMessageSent(targetSubnetId);
+    }
+
     /// @notice Returns the admin epoch
     function adminEpoch() external view override returns (uint256) {
         return _adminEpoch();

--- a/contracts/topos-core/ToposMessaging.sol
+++ b/contracts/topos-core/ToposMessaging.sol
@@ -135,21 +135,15 @@ contract ToposMessaging is IToposMessaging, EternalStorage {
     }
 
     /// @notice Entry point for sending a cross-subnet asset transfer
+    /// @dev The input data is sent to the target subnet externally
     /// @param targetSubnetId Target subnet ID
-    /// @param receiver Receiver's address
+    /// @param /*receiver*/ Receiver's address (avoiding unused local variable warning)
     /// @param tokenAddress Address of target token contract
     /// @param amount Amount of token to send
-    function sendToken(SubnetId targetSubnetId, address receiver, address tokenAddress, uint256 amount) external {
+    function sendToken(SubnetId targetSubnetId, address /*receiver*/, address tokenAddress, uint256 amount) external {
         if (_toposCoreAddr.code.length == uint256(0)) revert InvalidToposCore();
         _burnTokenFrom(msg.sender, tokenAddress, amount);
-        emit TokenSent(
-            msg.sender,
-            IToposCore(_toposCoreAddr).networkSubnetId(),
-            targetSubnetId,
-            receiver,
-            tokenAddress,
-            amount
-        );
+        IToposCore(_toposCoreAddr).emitCrossSubnetMessage(targetSubnetId);
     }
 
     /// @notice Gets the token by address

--- a/test/topos-core/ToposMessaging.test.ts
+++ b/test/topos-core/ToposMessaging.test.ts
@@ -701,15 +701,8 @@ describe('ToposMessaging', () => {
           ethers.constants.AddressZero,
           tc.SEND_AMOUNT_50
         )
-        .to.emit(toposMessaging, 'TokenSent')
-        .withArgs(
-          admin.address,
-          cc.SOURCE_SUBNET_ID_2,
-          cc.TARGET_SUBNET_ID_4,
-          tc.RECIPIENT_ADDRESS,
-          tokenAddress,
-          tc.SEND_AMOUNT_50
-        )
+        .to.emit(toposCore, 'CrossSubnetMessageSent')
+        .withArgs(cc.TARGET_SUBNET_ID_4)
     })
   })
 


### PR DESCRIPTION
# Description

In this PR, the `TokenSent` event has been removed from the `ToposMessaging` contract. As a result, the sequencer no longer needs to depend on the `ToposMessaging` contract/contracts to obtain the required information (which will be added to a certificate). For each asset transfer transaction, the `emitCrossSubnetMessage` method in the `ToposCore` contract must be invoked to signal that a cross-subnet messaging transaction has taken place.

## Additions and Changes

- Removes `TokenSent` event from `ToposMessaging` contract
- Adds a `CrossSubnetMessageSent` event in the `ToposCore` contract
- Adds a function `emitCrossSubnetMessage` in the `ToposCore` contract to emit an event whenever a cross-subnet messaging transaction is made
- Adapts unit test

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
