### PR TITLE
feat: verify if subnet already registered

### DIFF
--- a/scripts/register-subnet.ts
+++ b/scripts/register-subnet.ts
@@ -85,6 +85,17 @@ const main = async function (...args: string[]) {
     wallet
   )
 
+  const alreadyRegisteredSubnet = await verifyIfSubnetAlreadyRegistered(
+    contract,
+    subnetId
+  )
+  if (alreadyRegisteredSubnet.name) {
+    console.log(
+      `${alreadyRegisteredSubnet.name} is already registered with ${subnetId} subnet id!`
+    )
+    process.exit(0)
+  }
+
   const tx: ContractTransaction = await contract.registerSubnet(
     subnetRPCEndpoint,
     subnetLogoUrl,
@@ -106,6 +117,13 @@ const main = async function (...args: string[]) {
 
 const sanitizeHexString = function (hexString: string) {
   return hexString.startsWith('0x') ? hexString : `0x${hexString}`
+}
+
+const verifyIfSubnetAlreadyRegistered = function (
+  contract: Contract,
+  subnetId: string
+) {
+  return contract.subnets(subnetId) as Promise<{ name: string }>
 }
 
 const args = process.argv.slice(2)


### PR DESCRIPTION
# Description

#62 introduced a script to register subnets programmatically. This PR augments this script with a first step consisting of verifying whether the subnet has already been registered on the subnet. This is needed to make the script re-executable without failure (e.g., with a `docker compose down` and `docker compose up` situation).

Fixes TOO-289

## Additions and Changes

- Add a `verifyIfSubnetAlreadyRegistered` function and call it prior to registering the subnet

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
