### PR TITLE
feat: deploy contracts without const address deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ This script requires a few environment variables to be set:
 
 ### Deployment of the contracts on dynamic addresses
 
-To deploy the full Topos Messaging Protocol on dynamic contract addresses (could be any Ethereum compatible network, not just Polygon Edge network with predeployed const address deloyer contract), `deploy:topos-msg-protocol-dynamic` npm script is available. This script is intented for usage primarily during development. It deploys the following contracts:
+To deploy the full Topos Messaging Protocol on dynamic contract addresses (could be any Ethereum compatible network, not just Polygon Edge network with predeployed const address deployer contract), `deploy:topos-msg-protocol-dynamic` npm script is available. This script is intended for usage primarily during development. It deploys the following contracts:
 
-- `TokenDeployer` 
+- `TokenDeployer`
 - `ToposCore`
 - `ToposCoreProxy`
 - `ToposMessaging`

--- a/README.md
+++ b/README.md
@@ -124,14 +124,7 @@ $ npm run deploy:topos-msg-protocol-dynamic http://127.0.0.1:8545 0xac0974bec39a
 
 This script requires a few environment variables to be set:
 
-- TOKEN_DEPLOYER_SALT: salt for the `TokenDeployer` contract
-- TOPOS_CORE_SALT: salt for the `ToposCore` contract
-- TOPOS_CORE_PROXY_SALT: salt for the `ToposCoreProxy` contract
-- TOPOS_MESSAGING_SALT: salt for the `ToposMessaging` contract
 - PRIVATE_KEY: the private key of the account to be used to deploy contracts
-
-
-
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,33 @@ This script requires a few environment variables to be set:
 - TOPOS_MESSAGING_SALT: salt for the `ToposMessaging` contract
 - PRIVATE_KEY: the private key of the account to be used to deploy contracts
 
+### Deployment of the contracts on dynamic addresses
+
+To deploy the full Topos Messaging Protocol on a dynamic contract addresses (could be any Ethereum compatible network, not just Polygon Edge network with predeployed const address deloyer contract), `deploy:topos-msg-protocol-dynamic` npm script is available. This script is intented for usage primarily during development. It deploys the following contracts:
+
+- `TokenDeployer` 
+- `ToposCore`
+- `ToposCoreProxy`
+- `ToposMessaging`
+
+```
+$ npm run deploy:topos-msg-protocol-dynamic http://myChainRPCEndpoint sequencerPrivateKey
+
+E.g.
+$ npm run deploy:topos-msg-protocol-dynamic http://127.0.0.1:8545 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+```
+
+This script requires a few environment variables to be set:
+
+- TOKEN_DEPLOYER_SALT: salt for the `TokenDeployer` contract
+- TOPOS_CORE_SALT: salt for the `ToposCore` contract
+- TOPOS_CORE_PROXY_SALT: salt for the `ToposCoreProxy` contract
+- TOPOS_MESSAGING_SALT: salt for the `ToposMessaging` contract
+- PRIVATE_KEY: the private key of the account to be used to deploy contracts
+
+
+
+
 ## Docker
 
 Some of the above commands can be run in docker.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This script requires a few environment variables to be set:
 
 ### Deployment of the contracts on dynamic addresses
 
-To deploy the full Topos Messaging Protocol on a dynamic contract addresses (could be any Ethereum compatible network, not just Polygon Edge network with predeployed const address deloyer contract), `deploy:topos-msg-protocol-dynamic` npm script is available. This script is intented for usage primarily during development. It deploys the following contracts:
+To deploy the full Topos Messaging Protocol on dynamic contract addresses (could be any Ethereum compatible network, not just Polygon Edge network with predeployed const address deloyer contract), `deploy:topos-msg-protocol-dynamic` npm script is available. This script is intented for usage primarily during development. It deploys the following contracts:
 
 - `TokenDeployer` 
 - `ToposCore`

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "coverage": "hardhat coverage",
     "deploy": "ts-node scripts/deploy.ts",
     "deploy:topos-msg-protocol": "ts-node scripts/deploy-topos-msg-protocol.ts",
+    "deploy:topos-msg-protocol-dynamic": "ts-node scripts/deploy-topos-msg-protocol-dynamic.ts",
     "format": "npm run format:sol && npm run format:ts",
     "format:fix": "npm run format:sol:fix && npm run format:ts:fix",
     "format:sol": "prettier -c 'contracts/**/*.sol'",

--- a/scripts/deploy-topos-msg-protocol-dynamic.ts
+++ b/scripts/deploy-topos-msg-protocol-dynamic.ts
@@ -1,0 +1,146 @@
+import {
+  Contract,
+  ContractFactory,
+  ContractTransaction,
+  providers,
+  utils,
+  Wallet,
+} from 'ethers'
+
+import tokenDeployerJSON from '../artifacts/contracts/topos-core/TokenDeployer.sol/TokenDeployer.json'
+import toposCoreJSON from '../artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json'
+import toposCoreProxyJSON from '../artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json'
+import toposCoreInterfaceJSON from '../artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json'
+import toposMessagingJSON from '../artifacts/contracts/topos-core/ToposMessaging.sol/ToposMessaging.json'
+
+const main = async function (...args: string[]) {
+  const [providerEndpoint, _sequencerPrivateKey] = args
+  const provider = providers.getDefaultProvider(providerEndpoint)
+  const toposDeployerPrivateKey = sanitizeHexString(
+    process.env.PRIVATE_KEY || ''
+  )
+
+  if (!_sequencerPrivateKey) {
+    console.error('ERROR: Please provide the sequencer private key!')
+    process.exit(1)
+  }
+
+  const sequencerPrivateKey = sanitizeHexString(_sequencerPrivateKey)
+
+  if (!utils.isHexString(sequencerPrivateKey, 32)) {
+    console.error('ERROR: The sequencer private key is not a valid key!')
+    process.exit(1)
+  }
+
+  const isCompressed = true
+  const sequencerPublicKey = utils.computePublicKey(
+    sequencerPrivateKey,
+    isCompressed
+  )
+
+  const subnetId = sanitizeHexString(sequencerPublicKey.substring(4))
+
+  if (!utils.isHexString(toposDeployerPrivateKey, 32)) {
+    console.error(
+      'ERROR: Please provide a valid toposDeployer private key! (PRIVATE_KEY)'
+    )
+    process.exit(1)
+  }
+
+  const wallet = new Wallet(toposDeployerPrivateKey, provider)
+
+  // Deploy ConstAddressDeployer
+  const TokenDeployerFactory = new ContractFactory(
+    tokenDeployerJSON.abi,
+    tokenDeployerJSON.bytecode,
+    wallet
+  )
+  const TokenDeployer = await TokenDeployerFactory.deploy({
+    gasLimit: 8_000_000,
+  })
+  await TokenDeployer.deployed()
+  console.log(`Token Deployer deployed to ${TokenDeployer.address}`)
+
+  // Deploy ToposCore
+  const ToposCoreFactory = new ContractFactory(
+    toposCoreJSON.abi,
+    toposCoreJSON.bytecode,
+    wallet
+  )
+  const ToposCore = await ToposCoreFactory.deploy({
+    gasLimit: 8_000_000,
+  })
+  await ToposCore.deployed()
+  console.log(`Topos Core contract deployed to ${ToposCore.address}`)
+
+  // Deploy ToposCoreProxy
+  const toposCoreProxyParams = utils.defaultAbiCoder.encode(
+    ['address[]', 'uint256'],
+    [[wallet.address], 1] // TODO: Use a different admin address than ToposDeployer
+  )
+  const ToposCoreProxyFactory = new ContractFactory(
+    toposCoreProxyJSON.abi,
+    toposCoreProxyJSON.bytecode,
+    wallet
+  )
+  const ToposCoreProxy = await ToposCoreProxyFactory.deploy(
+    ToposCore.address,
+    toposCoreProxyParams,
+    { gasLimit: 8_000_000 }
+  )
+  await ToposCoreProxy.deployed()
+  console.log(`Topos Core Proxy contract deployed to ${ToposCoreProxy.address}`)
+
+  // Deploy ToposMessaging
+  const ToposMessagingFactory = new ContractFactory(
+    toposMessagingJSON.abi,
+    toposMessagingJSON.bytecode,
+    wallet
+  )
+  const ToposMessaging = await ToposMessagingFactory.deploy(
+    TokenDeployer.address,
+    ToposCoreProxy.address,
+    { gasLimit: 8_000_000 }
+  )
+  await ToposMessaging.deployed()
+  console.log(`Topos Messaging contract deployed to ${ToposMessaging.address}`)
+
+  console.info(`\nSetting subnetId on ToposCore via proxy`)
+  const toposCoreInterface = new Contract(
+    ToposCoreProxy.address,
+    toposCoreInterfaceJSON.abi,
+    wallet
+  )
+  await toposCoreInterface
+    .setNetworkSubnetId(subnetId, { gasLimit: 4_000_000 })
+    .then(async (tx: ContractTransaction) => {
+      await tx.wait().catch((error) => {
+        console.error(
+          `Error: Failed (wait) to set ${subnetId} subnetId on ToposCore via proxy!`
+        )
+        console.error(error)
+        process.exit(1)
+      })
+    })
+    .catch((error: Error) => {
+      console.error(
+        `Error: Failed to set ${subnetId} subnetId on ToposCore via proxy!`
+      )
+      console.error(error)
+      process.exit(1)
+    })
+
+  console.info(`\nReading subnet id`)
+  const networkSubnetId = await toposCoreInterface.networkSubnetId()
+
+  console.info(
+    `Successfully set ${networkSubnetId} subnetId on ToposCore via proxy\n`
+  )
+}
+
+const sanitizeHexString = function (hexString: string) {
+  return hexString.startsWith('0x') ? hexString : `0x${hexString}`
+}
+
+const args = process.argv.slice(2)
+main(...args)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,7 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true
-  }
+  },
+  "include": ["./scripts"],
+  "files": ["./hardhat.config.ts"]
 }


### PR DESCRIPTION
# Description

Introduce new script to deploy Topos contracts without pre-deployed fixed const address deployer contract (to other non Polygon Edge networks, e.g. Hardhat node)

Usage:
```
npm run deploy:topos-msg-protocol-dynamic <node json-rpc endpoint> <sequencer private key>
```
This script is primarily intended for fast development and testing of interaction of external components with Topos smart contracts.


## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
