### PR TITLE
chore: add typechain types to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "Jawad Tariq <sjcool420@hotmail.co.uk>",
   "main": "",
   "files": [
-    "artifacts"
+    "artifacts",
+    "typechain-types"
   ],
   "scripts": {
     "build": "hardhat compile",


### PR DESCRIPTION
# Description

`npm run build` generates `typechain` typings for typescript users but they are not included in the npm package. This PR fixes this by adding the `typechain-types` path to the package files.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
