### PR TITLE
ci: publish package to official npm registry

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -1,7 +1,7 @@
-name: Publish Package to Github Package NPM Registry
+name: Publish Package to NPM Registry
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   npm-package:
     runs-on: ubuntu-latest
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: 'https://registry.npmjs.org'
           scope: '@topos-network'
       - run: npm ci
       - run: npm run build
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Description

This PR replaces the Github NPM registry with the official npmjs.com one, so that consumers don't have to add an `.npmrc` file detailing custom registries.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
