### PR TITLE
fix: add missing npm pkg access

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -14,6 +14,6 @@ jobs:
           scope: '@topos-network'
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topos-network/topos-smart-contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Topos Smart Contracts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

#79 introduced the publication of the npm package to the npmjs.com registry. Unfortunately, the `--access public` flag for the `npm publish` command was missing, hence making the package private (with a failing publication).

This PR adds the missing flag and bumps the package version (we need to wait for `1.0.0` unpublication).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
