### PR TITLE
chore: split ToposMessaging & add ERC20Messaging

### DIFF
--- a/contracts/examples/ERC20Messaging.sol
+++ b/contracts/examples/ERC20Messaging.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "./Bytes32Sets.sol";
+import "./../topos-core/Bytes32Sets.sol";
 
 import "./../interfaces/IERC20Messaging.sol";
 import "./../interfaces/ITokenDeployer.sol";
 
 import {IBurnableMintableCappedERC20} from "./../interfaces/IBurnableMintableCappedERC20.sol";
-import {ToposMessaging} from "./ToposMessaging.sol";
+import {ToposMessaging} from "./../topos-core/ToposMessaging.sol";
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/interfaces/IERC20Messaging.sol
+++ b/contracts/interfaces/IERC20Messaging.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IToposMessaging, SubnetId} from "./IToposMessaging.sol";
+
+interface IERC20Messaging is IToposMessaging {
+    struct Token {
+        string symbol;
+        address addr;
+    }
+
+    enum TokenType {
+        InternalBurnableFrom,
+        External // Not supported yet
+    }
+
+    event TokenDailyMintLimitUpdated(address tokenAddress, uint256 limit);
+
+    event TokenDeployed(string symbol, address tokenAddress);
+
+    error BurnFailed(address tokenAddress);
+    error ExceedDailyMintLimit(address tokenAddress);
+    error InvalidAmount();
+    error InvalidSetDailyMintLimitsParams();
+    error InvalidTokenDeployer();
+    error TokenAlreadyExists(address tokenAddress);
+    error TokenDeployFailed();
+    error TokenDoesNotExist(address tokenAddress);
+    error UnsupportedTokenType();
+
+    function deployToken(bytes calldata params) external;
+
+    function sendToken(SubnetId targetSubnetId, address receiver, address tokenAddress, uint256 amount) external;
+
+    function getTokenByAddress(address tokenAddress) external view returns (Token memory token);
+
+    function getTokenCount() external view returns (uint256);
+
+    function getTokenKeyAtIndex(uint256 index) external view returns (bytes32);
+
+    function tokens(bytes32 tokenKey) external view returns (string memory, address);
+
+    function tokenDailyMintAmount(address tokenAddress) external view returns (uint256);
+
+    function tokenDailyMintLimit(address tokenAddress) external view returns (uint256);
+
+    function tokenDeployer() external view returns (address);
+}

--- a/contracts/interfaces/IToposMessaging.sol
+++ b/contracts/interfaces/IToposMessaging.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.9;
 
 import "solidity-rlp/contracts/RLPReader.sol";
+
 import {SubnetId} from "./IToposCore.sol";
 
 interface IToposMessaging {
@@ -13,63 +14,15 @@ interface IToposMessaging {
         RLPReader.RLPItem[] stack;
     }
 
-    struct Token {
-        string symbol;
-        address addr;
-    }
-
-    enum TokenType {
-        InternalBurnableFrom,
-        External // Not supported yet
-    }
-
-    event TokenDailyMintLimitUpdated(address tokenAddress, uint256 limit);
-
-    event TokenDeployed(string symbol, address tokenAddress);
-
-    error BurnFailed(address tokenAddress);
     error CertNotPresent();
-    error ExceedDailyMintLimit(address tokenAddress);
     error IllegalMemoryAccess();
-    error InvalidAmount();
     error InvalidMerkleProof();
-    error InvalidSetDailyMintLimitsParams();
     error InvalidSubnetId();
-    error InvalidTokenDeployer();
     error InvalidToposCore();
-    error TokenAlreadyExists(address tokenAddress);
-    error TokenDeployFailed();
-    error TokenDoesNotExist(address tokenAddress);
-    error TransferAlreadyExecuted();
+    error TransactionAlreadyExecuted();
     error UnsupportedProofKind();
-    error UnsupportedTokenType();
-
-    function deployToken(bytes calldata params) external;
-
-    function executeAssetTransfer(
-        uint256 indexOfDataInTxRaw,
-        bytes memory proofBlob,
-        bytes calldata txRaw,
-        bytes32 txRoot
-    ) external;
-
-    function sendToken(SubnetId targetSubnetId, address receiver, address tokenAddress, uint256 amount) external;
 
     function validateMerkleProof(bytes memory proofBlob, bytes32 txHash, bytes32 txRoot) external returns (bool);
 
-    function getTokenByAddress(address tokenAddress) external view returns (Token memory token);
-
-    function getTokenCount() external view returns (uint256);
-
-    function getTokenKeyAtIndex(uint256 index) external view returns (bytes32);
-
     function toposCore() external view returns (address);
-
-    function tokens(bytes32 tokenKey) external view returns (string memory, address);
-
-    function tokenDailyMintAmount(address tokenAddress) external view returns (uint256);
-
-    function tokenDailyMintLimit(address tokenAddress) external view returns (uint256);
-
-    function tokenDeployer() external view returns (address);
 }

--- a/contracts/topos-core/ERC20Messaging.sol
+++ b/contracts/topos-core/ERC20Messaging.sol
@@ -163,24 +163,12 @@ contract ERC20Messaging is IERC20Messaging, ToposMessaging {
 
         if (tokenType == TokenType.External) {
             revert UnsupportedTokenType();
-        } else if (tokenType == TokenType.InternalBurnableFrom) {
+        } else {
             burnSuccess = _callERC20Token(
                 tokenAddress,
                 abi.encodeWithSelector(IBurnableMintableCappedERC20.burnFrom.selector, sender, amount)
             );
             if (!burnSuccess) revert BurnFailed(tokenAddress);
-        } else {
-            burnSuccess = _callERC20Token(
-                tokenAddress,
-                abi.encodeWithSelector(
-                    IERC20.transferFrom.selector,
-                    sender,
-                    IBurnableMintableCappedERC20(tokenAddress).depositAddress(bytes32(0)),
-                    amount
-                )
-            );
-            if (!burnSuccess) revert BurnFailed(tokenAddress);
-            IBurnableMintableCappedERC20(tokenAddress).burn(bytes32(0));
         }
     }
 

--- a/contracts/topos-core/ERC20Messaging.sol
+++ b/contracts/topos-core/ERC20Messaging.sol
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "./Bytes32Sets.sol";
+
+import "./../interfaces/IERC20Messaging.sol";
+import "./../interfaces/ITokenDeployer.sol";
+
+import {IBurnableMintableCappedERC20} from "./../interfaces/IBurnableMintableCappedERC20.sol";
+import {ToposMessaging} from "./ToposMessaging.sol";
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract ERC20Messaging is IERC20Messaging, ToposMessaging {
+    using Bytes32SetsLib for Bytes32SetsLib.Set;
+
+    // Slot names should be prefixed with some standard string
+    bytes32 internal constant PREFIX_TOKEN_KEY = keccak256("token-key");
+    bytes32 internal constant PREFIX_TOKEN_TYPE = keccak256("token-type");
+    bytes32 internal constant PREFIX_TOKEN_DAILY_MINT_LIMIT = keccak256("token-daily-mint-limit");
+    bytes32 internal constant PREFIX_TOKEN_DAILY_MINT_AMOUNT = keccak256("token-daily-mint-amount");
+
+    /// @notice Set of Token Keys derived from token symbols
+    Bytes32SetsLib.Set tokenSet;
+
+    /// @notice Internal token deployer (ERCBurnableMintable by default)
+    address internal immutable _tokenDeployerAddr;
+
+    /// @notice Mapping to store Tokens
+    mapping(bytes32 => Token) public tokens;
+
+    /// @notice Constructor for ERC20Messaging contract
+    /// @param tokenDeployerAddr Address of the token deployer contract
+    constructor(address tokenDeployerAddr, address toposCoreAddr) ToposMessaging(toposCoreAddr) {
+        if (tokenDeployerAddr.code.length == uint256(0)) revert InvalidTokenDeployer();
+        _tokenDeployerAddr = tokenDeployerAddr;
+    }
+
+    /// @notice Deploy/register a token
+    /// @param params Encoded token params for deploying/registering a token
+    function deployToken(bytes calldata params) external {
+        (
+            string memory name,
+            string memory symbol,
+            uint256 cap,
+            address tokenAddress,
+            uint256 dailyMintLimit,
+            uint256 initialSupply
+        ) = abi.decode(params, (string, string, uint256, address, uint256, uint256));
+
+        // Ensure that this token does not exist already.
+        bytes32 tokenKey = _getTokenKey(tokenAddress);
+        if (tokenSet.exists(tokenKey)) revert TokenAlreadyExists(tokenAddress);
+
+        if (tokenAddress == address(0)) {
+            // If token address is no specified, it indicates a request to deploy one.
+            bytes32 salt = keccak256(abi.encodePacked(msg.sender, symbol));
+
+            // slither-disable-start reentrancy-no-eth
+            // solhint-disable-next-line avoid-low-level-calls
+            (bool success, bytes memory data) = _tokenDeployerAddr.delegatecall(
+                abi.encodeWithSelector(
+                    ITokenDeployer.deployToken.selector,
+                    name,
+                    symbol,
+                    cap,
+                    initialSupply,
+                    msg.sender,
+                    address(this),
+                    salt
+                )
+            );
+            // slither-disable-end reentrancy-no-eth
+
+            if (!success) revert TokenDeployFailed();
+
+            tokenAddress = abi.decode(data, (address));
+
+            _setTokenType(tokenAddress, TokenType.InternalBurnableFrom);
+        } else {
+            revert UnsupportedTokenType();
+            // _setTokenType(tokenAddress, TokenType.External);
+        }
+
+        _setTokenAddress(symbol, tokenAddress);
+        _setTokenDailyMintLimit(dailyMintLimit, tokenAddress);
+
+        emit TokenDeployed(symbol, tokenAddress);
+    }
+
+    /// @notice Entry point for sending a cross-subnet asset transfer
+    /// @dev The input data is sent to the target subnet externally
+    /// @param targetSubnetId Target subnet ID
+    /// @param /*receiver*/ Receiver's address (avoiding unused local variable warning)
+    /// @param tokenAddress Address of target token contract
+    /// @param amount Amount of token to send
+    function sendToken(SubnetId targetSubnetId, address /*receiver*/, address tokenAddress, uint256 amount) external {
+        if (_toposCoreAddr.code.length == uint256(0)) revert InvalidToposCore();
+        _burnTokenFrom(msg.sender, tokenAddress, amount);
+        _emitMessageSentEvent(targetSubnetId);
+    }
+
+    /// @notice Gets the token by address
+    /// @param tokenAddress Address of token contract
+    function getTokenByAddress(address tokenAddress) public view returns (Token memory token) {
+        bytes32 tokenKey = _getTokenKey(tokenAddress);
+        token = tokens[tokenKey];
+    }
+
+    /// @notice Get the number of tokens deployed/registered
+    function getTokenCount() public view returns (uint256) {
+        return tokenSet.count();
+    }
+
+    /// @notice Get the token key at the specified index
+    /// @param index Index of token key
+    function getTokenKeyAtIndex(uint256 index) public view returns (bytes32) {
+        return tokenSet.keyAtIndex(index);
+    }
+
+    /// @notice Get the token daily mint amount
+    /// @param tokenAddress Address of token contract
+    function tokenDailyMintAmount(address tokenAddress) public view returns (uint256) {
+        return getUint(_getTokenDailyMintAmountKey(tokenAddress, block.timestamp / 1 days));
+    }
+
+    /// @notice Get the token daily mint limit
+    /// @param tokenAddress Address of token contract
+    function tokenDailyMintLimit(address tokenAddress) public view returns (uint256) {
+        return getUint(_getTokenDailyMintLimitKey(tokenAddress));
+    }
+
+    /// @notice Get the address of token deployer contract
+    function tokenDeployer() public view returns (address) {
+        return _tokenDeployerAddr;
+    }
+
+    /// @notice Execute a cross-subnet asset transfer
+    /// @param indexOfDataInTxRaw Index of data in txRaw
+    /// @param txRaw Raw transaction data
+    function _execute(uint256 indexOfDataInTxRaw, bytes calldata txRaw) internal override {
+        (SubnetId targetSubnetId, address receiver, address tokenAddress, uint256 amount) = abi.decode(
+            txRaw[indexOfDataInTxRaw + 4:], // omit the 4 bytes function selector
+            (SubnetId, address, address, uint256)
+        );
+        if (!_validateTargetSubnetId(targetSubnetId)) revert InvalidSubnetId();
+
+        // prevent reentrancy
+        _mintToken(tokenAddress, receiver, amount);
+    }
+
+    /// @notice Burn token internally
+    /// @param sender Account to burn token from
+    /// @param tokenAddress Address of target token contract
+    /// @param amount Amount of token to burn
+    function _burnTokenFrom(address sender, address tokenAddress, uint256 amount) internal {
+        bytes32 tokenKey = _getTokenKey(tokenAddress);
+        if (!tokenSet.exists(tokenKey)) revert TokenDoesNotExist(tokenAddress);
+        if (amount == 0) revert InvalidAmount();
+
+        TokenType tokenType = _getTokenType(tokenAddress);
+        bool burnSuccess;
+
+        if (tokenType == TokenType.External) {
+            revert UnsupportedTokenType();
+        } else if (tokenType == TokenType.InternalBurnableFrom) {
+            burnSuccess = _callERC20Token(
+                tokenAddress,
+                abi.encodeWithSelector(IBurnableMintableCappedERC20.burnFrom.selector, sender, amount)
+            );
+            if (!burnSuccess) revert BurnFailed(tokenAddress);
+        } else {
+            burnSuccess = _callERC20Token(
+                tokenAddress,
+                abi.encodeWithSelector(
+                    IERC20.transferFrom.selector,
+                    sender,
+                    IBurnableMintableCappedERC20(tokenAddress).depositAddress(bytes32(0)),
+                    amount
+                )
+            );
+            if (!burnSuccess) revert BurnFailed(tokenAddress);
+            IBurnableMintableCappedERC20(tokenAddress).burn(bytes32(0));
+        }
+    }
+
+    /// @notice Low level call to external token contract
+    /// @dev Sends a low-level call to the token contract
+    /// @param tokenAddress Address of token contract
+    /// @param callData Data to call
+    function _callERC20Token(address tokenAddress, bytes memory callData) internal returns (bool) {
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returnData) = tokenAddress.call(callData);
+        return success && (returnData.length == uint256(0) || abi.decode(returnData, (bool)));
+    }
+
+    /// @notice Mint token internally
+    /// @param tokenAddress Address of token contract
+    /// @param account Account to mint token to
+    /// @param amount Amount of token to mint
+    function _mintToken(address tokenAddress, address account, uint256 amount) internal {
+        bytes32 tokenKey = _getTokenKey(tokenAddress);
+        if (!tokenSet.exists(tokenKey)) revert TokenDoesNotExist(tokenAddress);
+
+        _setTokenDailyMintAmount(tokenAddress, tokenDailyMintAmount(tokenAddress) + amount);
+
+        if (_getTokenType(tokenAddress) == TokenType.External) {
+            revert UnsupportedTokenType();
+        } else {
+            IBurnableMintableCappedERC20(tokenAddress).mint(account, amount);
+        }
+    }
+
+    /// @notice Store the token address for the specified symbol
+    /// @param symbol Symbol of token
+    /// @param tokenAddress Address of token contract
+    function _setTokenAddress(string memory symbol, address tokenAddress) internal {
+        bytes32 tokenKey = _getTokenKey(tokenAddress);
+        tokenSet.insert(tokenKey);
+        Token storage token = tokens[tokenKey];
+        token.symbol = symbol;
+        token.addr = tokenAddress;
+    }
+
+    /// @notice Set the token daily mint limit for a token address
+    /// @param limit Daily mint limit of token
+    /// @param tokenAddress Address of token contract
+    function _setTokenDailyMintLimit(uint256 limit, address tokenAddress) internal {
+        _setUint(_getTokenDailyMintLimitKey(tokenAddress), limit);
+
+        emit TokenDailyMintLimitUpdated(tokenAddress, limit);
+    }
+
+    /// @notice Set the token daily mint amount for a token address
+    /// @param tokenAddress Address of token contract
+    /// @param amount Daily mint amount of token
+    function _setTokenDailyMintAmount(address tokenAddress, uint256 amount) internal {
+        uint256 limit = tokenDailyMintLimit(tokenAddress);
+        if (limit > 0 && amount > limit) revert ExceedDailyMintLimit(tokenAddress);
+
+        _setUint(_getTokenDailyMintAmountKey(tokenAddress, block.timestamp / 1 days), amount);
+    }
+
+    /// @notice Set the token type for a token address
+    /// @param tokenAddress Address of token contract
+    /// @param tokenType Type of token (external/internal)
+    function _setTokenType(address tokenAddress, TokenType tokenType) internal {
+        _setUint(_getTokenTypeKey(tokenAddress), uint256(tokenType));
+    }
+
+    /// @notice Get the token type for a token address
+    /// @param tokenAddress Address of token contract
+    function _getTokenType(address tokenAddress) internal view returns (TokenType) {
+        return TokenType(getUint(_getTokenTypeKey(tokenAddress)));
+    }
+
+    /// @notice Get the key for the token daily mint limit
+    /// @param tokenAddress Address of token contract
+    function _getTokenDailyMintLimitKey(address tokenAddress) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(PREFIX_TOKEN_DAILY_MINT_LIMIT, tokenAddress));
+    }
+
+    /// @notice Get the key for the token daily mint amount
+    /// @param tokenAddress Address of token contract
+    /// @param day Day of token daily mint amount
+    function _getTokenDailyMintAmountKey(address tokenAddress, uint256 day) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(PREFIX_TOKEN_DAILY_MINT_AMOUNT, tokenAddress, day));
+    }
+
+    /// @notice Get the key for the token type
+    /// @param tokenAddress Address of token contract
+    function _getTokenTypeKey(address tokenAddress) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(PREFIX_TOKEN_TYPE, tokenAddress));
+    }
+
+    /// @notice Get the key for the token
+    /// @param tokenAddress Address of token contract
+    function _getTokenKey(address tokenAddress) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(PREFIX_TOKEN_KEY, tokenAddress));
+    }
+}

--- a/contracts/topos-core/ToposMessaging.sol
+++ b/contracts/topos-core/ToposMessaging.sol
@@ -1,117 +1,42 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "./Bytes32Sets.sol";
 import "./EternalStorage.sol";
 
-import "./../interfaces/IToposMessaging.sol";
 import "./../interfaces/IToposCore.sol";
-import "./../interfaces/ITokenDeployer.sol";
+import "./../interfaces/IToposMessaging.sol";
 
-import {IBurnableMintableCappedERC20} from "./../interfaces/IBurnableMintableCappedERC20.sol";
 import {MerklePatriciaProofVerifier} from "./MerklePatriciaProofVerifier.sol";
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 contract ToposMessaging is IToposMessaging, EternalStorage {
-    using Bytes32SetsLib for Bytes32SetsLib.Set;
     using RLPReader for RLPReader.RLPItem;
     using RLPReader for bytes;
 
     // Slot names should be prefixed with some standard string
-    bytes32 internal constant PREFIX_TOKEN_KEY = keccak256("token-key");
-    bytes32 internal constant PREFIX_TOKEN_TYPE = keccak256("token-type");
-    bytes32 internal constant PREFIX_SEND_TOKEN_EXECUTED = keccak256("send-token-executed");
-    bytes32 internal constant PREFIX_TOKEN_DAILY_MINT_LIMIT = keccak256("token-daily-mint-limit");
-    bytes32 internal constant PREFIX_TOKEN_DAILY_MINT_AMOUNT = keccak256("token-daily-mint-amount");
-
-    /// @notice Set of Token Keys derived from token symbols
-    Bytes32SetsLib.Set tokenSet;
+    bytes32 internal constant PREFIX_EXECUTED = keccak256("executed");
 
     /// @notice Internal topos core address
     address internal immutable _toposCoreAddr;
 
-    /// @notice Internal token deployer (ERCBurnableMintable by default)
-    address internal immutable _tokenDeployerAddr;
-
-    /// @notice Mapping to store Tokens
-    mapping(bytes32 => Token) public tokens;
-
     /// @notice Constructor for ToposMessaging contract
-    /// @param tokenDeployerAddr Address of token deployer
     /// @param toposCoreAddr Address of topos core
-    constructor(address tokenDeployerAddr, address toposCoreAddr) {
-        if (tokenDeployerAddr.code.length == uint256(0)) revert InvalidTokenDeployer();
+    constructor(address toposCoreAddr) {
         if (toposCoreAddr.code.length == uint256(0)) revert InvalidToposCore();
-        _tokenDeployerAddr = tokenDeployerAddr;
         _toposCoreAddr = toposCoreAddr;
     }
 
-    /// @notice Deploy/register a token
-    /// @param params Encoded token params for deploying/registering a token
-    function deployToken(bytes calldata params) external {
-        (
-            string memory name,
-            string memory symbol,
-            uint256 cap,
-            address tokenAddress,
-            uint256 dailyMintLimit,
-            uint256 initialSupply
-        ) = abi.decode(params, (string, string, uint256, address, uint256, uint256));
-
-        // Ensure that this token does not exist already.
-        bytes32 tokenKey = _getTokenKey(tokenAddress);
-        if (tokenSet.exists(tokenKey)) revert TokenAlreadyExists(tokenAddress);
-
-        if (tokenAddress == address(0)) {
-            // If token address is no specified, it indicates a request to deploy one.
-            bytes32 salt = keccak256(abi.encodePacked(msg.sender, symbol));
-
-            // slither-disable-start reentrancy-no-eth
-            // solhint-disable-next-line avoid-low-level-calls
-            (bool success, bytes memory data) = _tokenDeployerAddr.delegatecall(
-                abi.encodeWithSelector(
-                    ITokenDeployer.deployToken.selector,
-                    name,
-                    symbol,
-                    cap,
-                    initialSupply,
-                    msg.sender,
-                    address(this),
-                    salt
-                )
-            );
-            // slither-disable-end reentrancy-no-eth
-
-            if (!success) revert TokenDeployFailed();
-
-            tokenAddress = abi.decode(data, (address));
-
-            _setTokenType(tokenAddress, TokenType.InternalBurnableFrom);
-        } else {
-            revert UnsupportedTokenType();
-            // _setTokenType(tokenAddress, TokenType.External);
-        }
-
-        _setTokenAddress(symbol, tokenAddress);
-        _setTokenDailyMintLimit(dailyMintLimit, tokenAddress);
-
-        emit TokenDeployed(symbol, tokenAddress);
-    }
-
-    /// @notice Entry point for executing asset transfer
+    /// @notice Entry point for executing any message on a target subnet
     /// @param indexOfDataInTxRaw Index of tx.data in raw transaction hex
     /// @param txRaw RLP encoded raw transaction hex
     /// @param proofBlob RLP encoded proof blob
     /// @param txRoot Transactions root
-    function executeAssetTransfer(
+    function execute(
         uint256 indexOfDataInTxRaw,
-        bytes memory proofBlob,
+        bytes calldata proofBlob,
         bytes calldata txRaw,
         bytes32 txRoot
     ) external {
         if (_toposCoreAddr.code.length == uint256(0)) revert InvalidToposCore();
-
         if (txRaw.length < indexOfDataInTxRaw + 4) revert IllegalMemoryAccess();
 
         CertificateId certId = IToposCore(_toposCoreAddr).txRootToCertId(txRoot);
@@ -121,65 +46,12 @@ contract ToposMessaging is IToposMessaging, EternalStorage {
         // The transaction hash is used as a leaf to validate the inclusion proof.
         bytes32 txHash = keccak256(abi.encodePacked(txRaw));
         if (!validateMerkleProof(proofBlob, txHash, txRoot)) revert InvalidMerkleProof();
-        (SubnetId targetSubnetId, address receiver, address tokenAddress, uint256 amount) = abi.decode(
-            txRaw[indexOfDataInTxRaw + 4:], // omit the 4 bytes function selector
-            (SubnetId, address, address, uint256)
-        );
-        SubnetId toposCoreSubnetId = IToposCore(_toposCoreAddr).networkSubnetId();
-        if (SubnetId.unwrap(targetSubnetId) != SubnetId.unwrap(toposCoreSubnetId)) revert InvalidSubnetId();
 
-        if (_isSendTokenExecuted(txHash)) revert TransferAlreadyExecuted();
+        if (_isTxExecuted(txHash)) revert TransactionAlreadyExecuted();
 
         // prevent re-entrancy
-        _setSendTokenExecuted(txHash);
-        _mintToken(tokenAddress, receiver, amount);
-    }
-
-    /// @notice Entry point for sending a cross-subnet asset transfer
-    /// @dev The input data is sent to the target subnet externally
-    /// @param targetSubnetId Target subnet ID
-    /// @param /*receiver*/ Receiver's address (avoiding unused local variable warning)
-    /// @param tokenAddress Address of target token contract
-    /// @param amount Amount of token to send
-    function sendToken(SubnetId targetSubnetId, address /*receiver*/, address tokenAddress, uint256 amount) external {
-        if (_toposCoreAddr.code.length == uint256(0)) revert InvalidToposCore();
-        _burnTokenFrom(msg.sender, tokenAddress, amount);
-        IToposCore(_toposCoreAddr).emitCrossSubnetMessage(targetSubnetId);
-    }
-
-    /// @notice Gets the token by address
-    /// @param tokenAddress Address of token contract
-    function getTokenByAddress(address tokenAddress) public view returns (Token memory token) {
-        bytes32 tokenKey = _getTokenKey(tokenAddress);
-        token = tokens[tokenKey];
-    }
-
-    /// @notice Get the number of tokens deployed/registered
-    function getTokenCount() public view returns (uint256) {
-        return tokenSet.count();
-    }
-
-    /// @notice Get the token key at the specified index
-    /// @param index Index of token key
-    function getTokenKeyAtIndex(uint256 index) public view returns (bytes32) {
-        return tokenSet.keyAtIndex(index);
-    }
-
-    /// @notice Get the token daily mint amount
-    /// @param tokenAddress Address of token contract
-    function tokenDailyMintAmount(address tokenAddress) public view returns (uint256) {
-        return getUint(_getTokenDailyMintAmountKey(tokenAddress, block.timestamp / 1 days));
-    }
-
-    /// @notice Get the token daily mint limit
-    /// @param tokenAddress Address of token contract
-    function tokenDailyMintLimit(address tokenAddress) public view returns (uint256) {
-        return getUint(_getTokenDailyMintLimitKey(tokenAddress));
-    }
-
-    /// @notice Get the address of token deployer contract
-    function tokenDeployer() public view returns (address) {
-        return _tokenDeployerAddr;
+        _setTxExecuted(txHash);
+        _execute(indexOfDataInTxRaw, txRaw);
     }
 
     /// @notice Get the address of topos core contract
@@ -210,140 +82,40 @@ contract ToposMessaging is IToposMessaging, EternalStorage {
         }
     }
 
-    /// @notice Burn token internally
-    /// @param sender Account to burn token from
-    /// @param tokenAddress Address of target token contract
-    /// @param amount Amount of token to burn
-    function _burnTokenFrom(address sender, address tokenAddress, uint256 amount) internal {
-        bytes32 tokenKey = _getTokenKey(tokenAddress);
-        if (!tokenSet.exists(tokenKey)) revert TokenDoesNotExist(tokenAddress);
-        if (amount == 0) revert InvalidAmount();
+    /// @notice Execute the message on a target subnet
+    /// @dev This function should be implemented by the child contract
+    /// @param indexOfDataInTxRaw Index of tx.data in raw transaction hex
+    /// @param txRaw RLP encoded raw transaction hex
+    function _execute(uint256 indexOfDataInTxRaw, bytes calldata txRaw) internal virtual {}
 
-        TokenType tokenType = _getTokenType(tokenAddress);
-        bool burnSuccess;
-
-        if (tokenType == TokenType.External) {
-            revert UnsupportedTokenType();
-        } else {
-            burnSuccess = _callERC20Token(
-                tokenAddress,
-                abi.encodeWithSelector(IBurnableMintableCappedERC20.burnFrom.selector, sender, amount)
-            );
-            if (!burnSuccess) revert BurnFailed(tokenAddress);
-        }
-    }
-
-    /// @notice Low level call to external token contract
-    /// @dev Sends a low-level call to the token contract
-    /// @param tokenAddress Address of token contract
-    /// @param callData Data to call
-    function _callERC20Token(address tokenAddress, bytes memory callData) internal returns (bool) {
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool success, bytes memory returnData) = tokenAddress.call(callData);
-        return success && (returnData.length == uint256(0) || abi.decode(returnData, (bool)));
-    }
-
-    /// @notice Mint token internally
-    /// @param tokenAddress Address of token contract
-    /// @param account Account to mint token to
-    /// @param amount Amount of token to mint
-    function _mintToken(address tokenAddress, address account, uint256 amount) internal {
-        bytes32 tokenKey = _getTokenKey(tokenAddress);
-        if (!tokenSet.exists(tokenKey)) revert TokenDoesNotExist(tokenAddress);
-
-        _setTokenDailyMintAmount(tokenAddress, tokenDailyMintAmount(tokenAddress) + amount);
-
-        if (_getTokenType(tokenAddress) == TokenType.External) {
-            revert UnsupportedTokenType();
-        } else {
-            IBurnableMintableCappedERC20(tokenAddress).mint(account, amount);
-        }
+    /// @notice emit a message sent event from the ToposCore contract
+    function _emitMessageSentEvent(SubnetId targetSubnetId) internal {
+        IToposCore(_toposCoreAddr).emitCrossSubnetMessage(targetSubnetId);
     }
 
     /// @notice Set a flag to indicate that the asset transfer transaction has been executed
     /// @param txHash Hash of asset transfer transaction
-    function _setSendTokenExecuted(bytes32 txHash) internal {
-        _setBool(_getIsSendTokenExecutedKey(txHash), true);
+    function _setTxExecuted(bytes32 txHash) internal {
+        _setBool(_getTxExecutedKey(txHash), true);
     }
 
-    /// @notice Store the token address for the specified symbol
-    /// @param symbol Symbol of token
-    /// @param tokenAddress Address of token contract
-    function _setTokenAddress(string memory symbol, address tokenAddress) internal {
-        bytes32 tokenKey = _getTokenKey(tokenAddress);
-        tokenSet.insert(tokenKey);
-        Token storage token = tokens[tokenKey];
-        token.symbol = symbol;
-        token.addr = tokenAddress;
+    /// @notice Get the flag to indicate that the transaction has been executed
+    /// @param txHash transaction hash
+    function _isTxExecuted(bytes32 txHash) internal view returns (bool) {
+        return getBool(_getTxExecutedKey(txHash));
     }
 
-    /// @notice Set the token daily mint limit for a token address
-    /// @param limit Daily mint limit of token
-    /// @param tokenAddress Address of token contract
-    function _setTokenDailyMintLimit(uint256 limit, address tokenAddress) internal {
-        _setUint(_getTokenDailyMintLimitKey(tokenAddress), limit);
-
-        emit TokenDailyMintLimitUpdated(tokenAddress, limit);
+    /// @notice Validate that the target subnet id is the same as the subnet id of the topos core
+    /// @param targetSubnetId Subnet id of the target subnet
+    function _validateTargetSubnetId(SubnetId targetSubnetId) internal view returns (bool) {
+        SubnetId toposCoreSubnetId = IToposCore(_toposCoreAddr).networkSubnetId();
+        return (SubnetId.unwrap(targetSubnetId) == SubnetId.unwrap(toposCoreSubnetId));
     }
 
-    /// @notice Set the token daily mint amount for a token address
-    /// @param tokenAddress Address of token contract
-    /// @param amount Daily mint amount of token
-    function _setTokenDailyMintAmount(address tokenAddress, uint256 amount) internal {
-        uint256 limit = tokenDailyMintLimit(tokenAddress);
-        if (limit > 0 && amount > limit) revert ExceedDailyMintLimit(tokenAddress);
-
-        _setUint(_getTokenDailyMintAmountKey(tokenAddress, block.timestamp / 1 days), amount);
-    }
-
-    /// @notice Set the token type for a token address
-    /// @param tokenAddress Address of token contract
-    /// @param tokenType Type of token (external/internal)
-    function _setTokenType(address tokenAddress, TokenType tokenType) internal {
-        _setUint(_getTokenTypeKey(tokenAddress), uint256(tokenType));
-    }
-
-    /// @notice Get the token type for a token address
-    /// @param tokenAddress Address of token contract
-    function _getTokenType(address tokenAddress) internal view returns (TokenType) {
-        return TokenType(getUint(_getTokenTypeKey(tokenAddress)));
-    }
-
-    /// @notice Get the flag to indicate that the asset transfer transaction has been executed
-    /// @param txHash Hash of asset transfer transaction
-    function _isSendTokenExecuted(bytes32 txHash) internal view returns (bool) {
-        return getBool(_getIsSendTokenExecutedKey(txHash));
-    }
-
-    /// @notice Get the key for the token daily mint limit
-    /// @param tokenAddress Address of token contract
-    function _getTokenDailyMintLimitKey(address tokenAddress) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(PREFIX_TOKEN_DAILY_MINT_LIMIT, tokenAddress));
-    }
-
-    /// @notice Get the key for the token daily mint amount
-    /// @param tokenAddress Address of token contract
-    /// @param day Day of token daily mint amount
-    function _getTokenDailyMintAmountKey(address tokenAddress, uint256 day) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(PREFIX_TOKEN_DAILY_MINT_AMOUNT, tokenAddress, day));
-    }
-
-    /// @notice Get the key for the token type
-    /// @param tokenAddress Address of token contract
-    function _getTokenTypeKey(address tokenAddress) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(PREFIX_TOKEN_TYPE, tokenAddress));
-    }
-
-    /// @notice Get the key for the token
-    /// @param tokenAddress Address of token contract
-    function _getTokenKey(address tokenAddress) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(PREFIX_TOKEN_KEY, tokenAddress));
-    }
-
-    /// @notice Get the key for the flag to indicate that the asset transfer transaction has been executed
-    /// @param txHash Hash of asset transfer transaction
-    function _getIsSendTokenExecutedKey(bytes32 txHash) internal pure returns (bytes32) {
-        return keccak256(abi.encode(PREFIX_SEND_TOKEN_EXECUTED, txHash));
+    /// @notice Get the key for the flag to indicate that the transaction has been executed
+    /// @param txHash transaction hash
+    function _getTxExecutedKey(bytes32 txHash) internal pure returns (bytes32) {
+        return keccak256(abi.encode(PREFIX_EXECUTED, txHash));
     }
 
     /// @notice Decode the proof blob into Proof struct

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topos-network/topos-smart-contracts",
-  "version": "1.1.1-rc1",
+  "version": "1.1.1-rc2",
   "description": "Topos Smart Contracts",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topos-network/topos-smart-contracts",
-  "version": "1.0.1",
+  "version": "1.1.1-rc1",
   "description": "Topos Smart Contracts",
   "repository": {
     "type": "git",

--- a/scripts/deploy-topos-msg-protocol-dynamic.ts
+++ b/scripts/deploy-topos-msg-protocol-dynamic.ts
@@ -11,7 +11,7 @@ import tokenDeployerJSON from '../artifacts/contracts/topos-core/TokenDeployer.s
 import toposCoreJSON from '../artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json'
 import toposCoreProxyJSON from '../artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json'
 import toposCoreInterfaceJSON from '../artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json'
-import toposMessagingJSON from '../artifacts/contracts/topos-core/ToposMessaging.sol/ToposMessaging.json'
+import erc20MessagingJSON from '../artifacts/contracts/topos-core/ERC20Messaging.sol/ERC20Messaging.json'
 
 const main = async function (...args: string[]) {
   const [providerEndpoint, _sequencerPrivateKey] = args
@@ -91,19 +91,19 @@ const main = async function (...args: string[]) {
   await ToposCoreProxy.deployed()
   console.log(`Topos Core Proxy contract deployed to ${ToposCoreProxy.address}`)
 
-  // Deploy ToposMessaging
-  const ToposMessagingFactory = new ContractFactory(
-    toposMessagingJSON.abi,
-    toposMessagingJSON.bytecode,
+  // Deploy ERC20Messaging
+  const ERC20MessagingFactory = new ContractFactory(
+    erc20MessagingJSON.abi,
+    erc20MessagingJSON.bytecode,
     wallet
   )
-  const ToposMessaging = await ToposMessagingFactory.deploy(
+  const ERC20Messaging = await ERC20MessagingFactory.deploy(
     TokenDeployer.address,
     ToposCoreProxy.address,
     { gasLimit: 5_000_000 }
   )
-  await ToposMessaging.deployed()
-  console.log(`Topos Messaging contract deployed to ${ToposMessaging.address}`)
+  await ERC20Messaging.deployed()
+  console.log(`ERC20 Messaging contract deployed to ${ERC20Messaging.address}`)
 
   console.info(`\nSetting subnetId on ToposCore via proxy`)
   const toposCoreInterface = new Contract(

--- a/scripts/deploy-topos-msg-protocol-dynamic.ts
+++ b/scripts/deploy-topos-msg-protocol-dynamic.ts
@@ -11,7 +11,7 @@ import tokenDeployerJSON from '../artifacts/contracts/topos-core/TokenDeployer.s
 import toposCoreJSON from '../artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json'
 import toposCoreProxyJSON from '../artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json'
 import toposCoreInterfaceJSON from '../artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json'
-import erc20MessagingJSON from '../artifacts/contracts/topos-core/ERC20Messaging.sol/ERC20Messaging.json'
+import erc20MessagingJSON from '../artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json'
 
 const main = async function (...args: string[]) {
   const [providerEndpoint, _sequencerPrivateKey] = args

--- a/scripts/deploy-topos-msg-protocol.ts
+++ b/scripts/deploy-topos-msg-protocol.ts
@@ -4,7 +4,7 @@ import tokenDeployerJSON from '../artifacts/contracts/topos-core/TokenDeployer.s
 import toposCoreJSON from '../artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json'
 import toposCoreProxyJSON from '../artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json'
 import toposCoreInterfaceJSON from '../artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json'
-import toposMessagingJSON from '../artifacts/contracts/topos-core/ToposMessaging.sol/ToposMessaging.json'
+import erc20MessagingJSON from '../artifacts/contracts/topos-core/ERC20Messaging.sol/ERC20Messaging.json'
 import {
   Arg,
   ContractOutputJSON,
@@ -21,7 +21,7 @@ const main = async function (...args: string[]) {
   const tokenDeployerSalt = process.env.TOKEN_DEPLOYER_SALT
   const toposCoreSalt = process.env.TOPOS_CORE_SALT
   const toposCoreProxySalt = process.env.TOPOS_CORE_PROXY_SALT
-  const toposMessagingSalt = process.env.TOPOS_MESSAGING_SALT
+  const erc20MessagingSalt = process.env.ERC20_MESSAGING_SALT
 
   if (!_sequencerPrivateKey) {
     console.error('ERROR: Please provide the sequencer private key!')
@@ -53,7 +53,7 @@ const main = async function (...args: string[]) {
   verifySalt('TokenDeployer', 'TOKEN_DEPLOYER_SALT', tokenDeployerSalt)
   verifySalt('ToposCore', 'TOPOS_CORE_SALT', toposCoreSalt)
   verifySalt('ToposCoreProxy', 'TOPOS_CORE_PROXY_SALT', toposCoreProxySalt)
-  verifySalt('TokenMessaging', 'TOPOS_MESSAGING_SALT', toposMessagingSalt)
+  verifySalt('ERC20Messaging', 'ERC20_MESSAGING_SALT', erc20MessagingSalt)
 
   const wallet = new Wallet(toposDeployerPrivateKey, provider)
 
@@ -89,10 +89,10 @@ const main = async function (...args: string[]) {
   )
 
   await processContract(
-    'ToposMessaging',
+    'ERC20Messaging',
     wallet,
-    toposMessagingJSON,
-    toposMessagingSalt!,
+    erc20MessagingJSON,
+    erc20MessagingSalt!,
     [tokenDeployerAddress, toposCoreProxyAddress],
     4_000_000
   )

--- a/scripts/deploy-topos-msg-protocol.ts
+++ b/scripts/deploy-topos-msg-protocol.ts
@@ -4,7 +4,7 @@ import tokenDeployerJSON from '../artifacts/contracts/topos-core/TokenDeployer.s
 import toposCoreJSON from '../artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json'
 import toposCoreProxyJSON from '../artifacts/contracts/topos-core/ToposCoreProxy.sol/ToposCoreProxy.json'
 import toposCoreInterfaceJSON from '../artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json'
-import erc20MessagingJSON from '../artifacts/contracts/topos-core/ERC20Messaging.sol/ERC20Messaging.json'
+import erc20MessagingJSON from '../artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json'
 import {
   Arg,
   ContractOutputJSON,

--- a/scripts/test/send-token.ts
+++ b/scripts/test/send-token.ts
@@ -2,7 +2,7 @@ import { Contract, providers, utils, Wallet, constants } from 'ethers'
 import { keccak256 } from '@ethersproject/keccak256'
 import { toUtf8Bytes } from '@ethersproject/strings'
 
-import erc20MessagingJSON from '../../artifacts/contracts/topos-core/ERC20Messaging.sol/ERC20Messaging.json'
+import erc20MessagingJSON from '../../artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json'
 import toposCoreInterfaceJSON from '../../artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json'
 import ERC20 from '../../artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json'
 

--- a/scripts/test/send-token.ts
+++ b/scripts/test/send-token.ts
@@ -2,7 +2,7 @@ import { Contract, providers, utils, Wallet, constants } from 'ethers'
 import { keccak256 } from '@ethersproject/keccak256'
 import { toUtf8Bytes } from '@ethersproject/strings'
 
-import toposMessagingInterfaceJSON from '../../artifacts/contracts/interfaces/IToposMessaging.sol/IToposMessaging.json'
+import erc20MessagingJSON from '../../artifacts/contracts/topos-core/ERC20Messaging.sol/ERC20Messaging.json'
 import toposCoreInterfaceJSON from '../../artifacts/contracts/interfaces/IToposCore.sol/IToposCore.json'
 import ERC20 from '../../artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json'
 
@@ -17,13 +17,13 @@ import * as testUtils from '../../test/topos-core/shared/utils/common'
 const main = async function (...args: string[]) {
   const [providerEndpoint, senderPrivateKey, receiverAddress, amount] = args
   const provider = providers.getDefaultProvider(providerEndpoint)
-  const toposMessagingAddress = sanitizeHexString(
-    process.env.TOPOS_MESSAGING_ADDRESS || ''
+  const erc20MessagingAddress = sanitizeHexString(
+    process.env.ERC20_MESSAGING_ADDRESS || ''
   )
 
-  if (!utils.isHexString(toposMessagingAddress, 20)) {
+  if (!utils.isHexString(erc20MessagingAddress, 20)) {
     console.error(
-      'ERROR: Please set token deployer contract address TOPOS_MESSAGING_ADDRESS'
+      'ERROR: Please set token deployer contract address ERC20_MESSAGING_ADDRESS'
     )
     process.exit(1)
   }
@@ -41,9 +41,9 @@ const main = async function (...args: string[]) {
 
   const wallet = new Wallet(senderPrivateKey, provider)
 
-  const toposMessaging = new Contract(
-    toposMessagingAddress,
-    toposMessagingInterfaceJSON.abi,
+  const erc20Messaging = new Contract(
+    erc20MessagingAddress,
+    erc20MessagingJSON.abi,
     wallet
   )
   const toposCoreProxy = new Contract(
@@ -67,10 +67,10 @@ const main = async function (...args: string[]) {
   let deploy = true
   let tokenAddress = null
   // Check if token is already deployed. If not, deploy it
-  const numberOfTokens = await toposMessaging.getTokenCount()
+  const numberOfTokens = await erc20Messaging.getTokenCount()
   for (let index = 0; index < numberOfTokens; index++) {
-    const tokenKey = await toposMessaging.getTokenKeyAtIndex(index)
-    const [token, address] = await toposMessaging.tokens(tokenKey)
+    const tokenKey = await erc20Messaging.getTokenKeyAtIndex(index)
+    const [token, address] = await erc20Messaging.tokens(tokenKey)
     if (token == tc.TOKEN_SYMBOL_X) {
       deploy = false
       console.log(
@@ -87,7 +87,7 @@ const main = async function (...args: string[]) {
 
   if (deploy) {
     // Deploy token if not previously deployed
-    const tx = await toposMessaging.deployToken(defaultToken, {
+    const tx = await erc20Messaging.deployToken(defaultToken, {
       gasLimit: 5_000_000,
     })
     const txReceipt = await tx.wait()
@@ -104,7 +104,7 @@ const main = async function (...args: string[]) {
 
   // Approve token burn
   const erc20 = new Contract(tokenAddress, ERC20.abi, wallet)
-  await erc20.approve(toposMessaging.address, amount)
+  await erc20.approve(erc20Messaging.address, amount)
 
   // Send token
   console.log(
@@ -119,7 +119,7 @@ const main = async function (...args: string[]) {
     ' token address:',
     tokenAddress
   )
-  const tx = await toposMessaging.sendToken(
+  const tx = await erc20Messaging.sendToken(
     cc.TARGET_SUBNET_ID_4,
     receiverAddress,
     tokenAddress,


### PR DESCRIPTION
# Description

This pull request introduces a division of the current `ToposMessaging.sol` smart contract into two separate contracts: a parent contract (`ToposMessaging.sol`) and a child contract (`ERC20Messaging.sol`). The rationale behind this design choice is based on the concept that the `ToposMessaging` contract is responsible for carrying out general input validation for the incoming transactions. After the common validation is completed, the data is redirected to the child contract, which handles any application-specific data validation.
In summary, each application-specific child smart contract intended for use in the cross-subnet messaging protocol inherits the parent contract, allowing dApp developers to focus solely on application-specific data validation.

Fixes TP-596

## Additions and Changes

- Added `ERC20Messaging.sol` contract and moved the ERC20 token cross-subnet transfer logic to the new contract
- Renamed the `executeAssetTransfer` method to `execute` and moved it to the parent contract
- Added a _virtual_ method `_execute` in the parent (`ToposMessaging.sol`) contract, which the child contract needs to _override_ in order to implement application-specific input validation
- Adapted the unit tests

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
