### PR TITLE
ci: add release-pipeline workflow

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1,0 +1,20 @@
+name: Release Pipeline
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "repository": "${{ github.repository }}",
+              "version": "${{ github.ref }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ vars.RELEASE_PIPELINE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Description

This PR adds a new CI workflow for sending Slack notifications upon new releases.

The Slack notification will help prevent multiple new releases from different stack components to miss each other's e2e tests run by the new `topos-network/e2e-tests` project.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
