### PR TITLE
fix: trigger e2e tests for PR updates only

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/docker_utils.yml
   e2e:
     needs: docker
+    if: ${{ github.event_name == "pull_request" }}
     runs-on: ubuntu-latest-16-core
     steps:
       - name: Set environment


### PR DESCRIPTION
# Description

#90 introduced triggering e2e tests remotely on many topos-smart-contracts triggers. This PR updates the condition of the e2e trigger job so that it is only run on PR updates (otherwise the relevant docker tag is not fetchable—because there are many of tem).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
