### PR TITLE
fix: use single quotes in workflow if condition

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/docker_utils.yml
   e2e:
     needs: docker
-    if: ${{ github.event_name == "pull_request" }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest-16-core
     steps:
       - name: Set environment


### PR DESCRIPTION
# Description

#91 introduced filtering triggers for the e2e tests remote workflow execution, unfortunately double quotes were used instead of single quotes.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
