### PR TITLE
test: trigger sequencer e2e tests

### DIFF
--- a/.github/workflows/sequencer-e2e.yml
+++ b/.github/workflows/sequencer-e2e.yml
@@ -1,0 +1,24 @@
+name: Sequencer-Contracts e2e test
+
+on:
+  pull_request:
+    branches: main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sequencer-contracts-e2e:
+    runs-on: ubuntu-latest-16-core
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: topos-network
+          repo: e2e-tests
+          github_token: ${{ secrets.ROBOT_PAT_TRIGGER_E2E_WORKFLOWS }}
+          workflow_file_name: topos:sequencer-contracts.yml
+          ref: main
+          wait_interval: 60
+          client_payload: '{ "topos-smart-contracts-ref": "${{ github.head_ref }}" }'


### PR DESCRIPTION
# Description

This PR adds a CI workflow to trigger the sequencer-contracts e2e test remotely.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
